### PR TITLE
#234-password-reset

### DIFF
--- a/src/containers/guest-home-page/forgot-password/ForgotPassword.styles.js
+++ b/src/containers/guest-home-page/forgot-password/ForgotPassword.styles.js
@@ -25,7 +25,8 @@ export const styles = {
       mb: '16px'
     },
     description: {
-      typography: 'body2'
+      typography: 'body2',
+      mb: '32px'
     }
   }
 }


### PR DESCRIPTION
The “Email” input field was overlapped by description text on the password reset pop-up. This fix adjusts the layout and spacing to prevent overlap.

BEFORE fix:
![image](https://github.com/user-attachments/assets/5931b2cd-b7ee-401e-b254-56c74f210008)


AFTER fix:
![image](https://github.com/user-attachments/assets/c9be64bc-8522-433d-95cd-ecc750d8e6da)

