### PR TITLE
#231-fixed-bold-text

### DIFF
--- a/src/styles/app-theme/app.typography.ts
+++ b/src/styles/app-theme/app.typography.ts
@@ -55,7 +55,7 @@ const appTypography: AppTypography = {
     letterSpacing: '0.15px'
   },
   subtitle2: {
-    fontWeight: 500,
+    fontWeight: 400,
     fontSize: '14px',
     lineHeight: '20px',
     letterSpacing: '0.1px'


### PR DESCRIPTION
I need to remove the bold font from item descriptions. So in the figma layout

![4](https://github.com/user-attachments/assets/43df5bea-d36b-439a-8792-5d3075eb8b1d)

that's how it was

![5](https://github.com/user-attachments/assets/7601ae32-768c-4a0c-abd1-5167e4b3148d)

so now

![6](https://github.com/user-attachments/assets/ec7e565f-da0b-47f0-9fc3-7ca822803472)
