### PR TITLE
#228-text-error-fixed

### DIFF
--- a/src/constants/translations/en/guest-home-page.json
+++ b/src/constants/translations/en/guest-home-page.json
@@ -23,7 +23,7 @@
   },
   "whatCanYouDo": {
     "title": "What can you do",
-    "description": "Whether you’re looking for a tutor or to looking become one – you’ve come to the right place.",
+    "description": "Whether you’re looking for a tutor or looking to become one – you’ve come to the right place.",
     "learn": {
       "title": "Learn from experts",
       "description": "Learning from experts is a shortcut to mastery. Their knowledge and experience can guide you, unlocking your potential. Don't put off until tomorrow. Embrace it! 🌟",


### PR DESCRIPTION
I fixed a small text error in the “What can you do” block on the home page. The title text did not match the mockup, so I found the correct file and made the necessary correction.
It was like this
![Знімок екрана 2025-04-11 134803](https://github.com/user-attachments/assets/aef62b51-58df-466a-8043-362ed7a88f4f)
Now it’s like this
![Знімок екрана 2025-04-11 134721](https://github.com/user-attachments/assets/980311af-bcf2-49f3-9c17-5f42b011839a)
