### PR TITLE
#230 Changed button text

### DIFF
--- a/src/constants/translations/en/guest-home-page.json
+++ b/src/constants/translations/en/guest-home-page.json
@@ -27,12 +27,12 @@
     "learn": {
       "title": "Learn from experts",
       "description": "Learning from experts is a shortcut to mastery. Their knowledge and experience can guide you, unlocking your potential. Don't put off until tomorrow. Embrace it! 🌟",
-      "actionLabel": "Become a student"
+      "actionLabel": "Join as a student"
     },
     "teach": {
       "title": "Share your experience",
       "description": "Sharing your experience as an expert will be incredibly rewarding, helping students unlock their pоtential and achieve their goals. Don't waste your time 📚",
-      "actionLabel": "Become a tutor"
+      "actionLabel": "Join as a tutor"
     }
   },
   "howItWorks": {


### PR DESCRIPTION
Changed button text for both student and tutor. 

Before:
<img width="1336" alt="Screenshot 2025-04-13 at 08 34 12" src="https://github.com/user-attachments/assets/5725bf7a-6ffd-4f8a-9ff9-1f4349b032ed" />
<img width="1172" alt="Screenshot 2025-04-13 at 08 35 16" src="https://github.com/user-attachments/assets/aafbca44-56ae-4556-ae9a-8fe56a2c6fd8" />

After:
<img width="1361" alt="Screenshot 2025-04-13 at 08 36 32" src="https://github.com/user-attachments/assets/a6a03e2f-ff0f-4ff0-af30-ef65fe87c2e8" />
<img width="1017" alt="Screenshot 2025-04-13 at 08 37 06" src="https://github.com/user-attachments/assets/79f954f7-304b-4f15-9dcb-b5818281ee5e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the language on the guest home page to be more engaging. The call-to-action labels now read “Join as a student” and “Join as a tutor” to encourage greater participation. This update refines the user messaging and aims to make the platform more approachable. Enhancing the inviting tone is expected to improve onboarding and overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->