### PR TITLE
Test #56 tests for slider input with input component

### DIFF
--- a/src/tests/unit/components/slider-with-input/SliderWithInput.spec.jsx
+++ b/src/tests/unit/components/slider-with-input/SliderWithInput.spec.jsx
@@ -1,12 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import SliderWithInput from '~/components/slider-with-input/SliderWithInput'
-
-const defaultValue = 0
-const title = 'hello'
-const max = 5
-const min = 0
-const onChange = vi.fn()
+import userEvent from '@testing-library/user-event'
 
 // interface SliderWithInputProps {
 //     defaultValue: number
@@ -18,21 +13,43 @@ const onChange = vi.fn()
 
 describe('SliderWithInput', () => {
   it('should render correctly', () => {
+    const handleChange = vi.fn()
     render(
       <SliderWithInput
-        defaultValue={defaultValue}
-        max={max}
-        min={min}
-        onChange={onChange}
-        title={title}
+        defaultValue={50}
+        max={100}
+        min={0}
+        onChange={handleChange}
+        title='Volume'
       />
     )
-    const titleElement = screen.getByText(title)
+    const titleElement = screen.getByText('Volume')
     expect(titleElement).toBeInTheDocument()
-    screen.logTestingPlaygroundURL()
   })
 
-  it('should call onChange when slider is moved', () => {})
+  it('should call onChange when slider is moved', async () => {
+    const user = userEvent.setup()
+    const handleChange = vi.fn()
+
+    render(
+      <SliderWithInput
+        defaultValue={50}
+        max={100}
+        min={0}
+        onChange={handleChange}
+        title='Volume'
+      />
+    )
+
+    /*
+    mock a onChange fn -> find user-event for a slider move 
+    */
+
+    const slider = screen.getByRole('slider')
+
+    await user.click(slider)
+    expect(slider).toHaveFocus()
+  })
 
   it('should update inputValue correctly when input value is empty', () => {})
   it('should not update prices when input is blurred and value in input has not changed', () => {})

--- a/src/tests/unit/components/slider-with-input/SliderWithInput.spec.jsx
+++ b/src/tests/unit/components/slider-with-input/SliderWithInput.spec.jsx
@@ -1,57 +1,100 @@
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import SliderWithInput from '~/components/slider-with-input/SliderWithInput'
-import userEvent from '@testing-library/user-event'
 
-// interface SliderWithInputProps {
-//     defaultValue: number
-//     title: string
-//     max: number
-//     min: number
-//     onChange: (value: number) => void
-//   }
+const handleChangeMock = vi.fn()
+
+const defaultValue = 50
+const min = 0
+const max = 100
+const title = 'Test'
+
+const delay = 500
 
 describe('SliderWithInput', () => {
-  it('should render correctly', () => {
-    const handleChange = vi.fn()
+  beforeEach(() => {
+    vi.useFakeTimers()
     render(
       <SliderWithInput
-        defaultValue={50}
-        max={100}
-        min={0}
-        onChange={handleChange}
-        title='Volume'
+        defaultValue={defaultValue}
+        max={max}
+        min={min}
+        onChange={handleChangeMock}
+        title={title}
       />
     )
-    const titleElement = screen.getByText('Volume')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should render correctly', () => {
+    const titleElement = screen.getByText('Test')
+
     expect(titleElement).toBeInTheDocument()
   })
 
-  it('should call onChange when slider is moved', async () => {
-    const user = userEvent.setup()
-    const handleChange = vi.fn()
-
-    render(
-      <SliderWithInput
-        defaultValue={50}
-        max={100}
-        min={0}
-        onChange={handleChange}
-        title='Volume'
-      />
-    )
-
-    /*
-    mock a onChange fn -> find user-event for a slider move 
-    */
-
+  it('should call onChange when slider is moved', () => {
     const slider = screen.getByRole('slider')
+    const inputValue = 100
 
-    await user.click(slider)
-    expect(slider).toHaveFocus()
+    fireEvent.change(slider, { target: { value: inputValue } })
+    vi.advanceTimersByTime(delay)
+
+    expect(handleChangeMock).toHaveBeenCalledWith(inputValue)
   })
 
-  it('should update inputValue correctly when input value is empty', () => {})
-  it('should not update prices when input is blurred and value in input has not changed', () => {})
-  it('should update prices when input is blurred and input is greater than max value', () => {})
+  it('should sync slider and input values', () => {
+    const slider = screen.getByRole('slider')
+    const input = screen.getByRole('textbox')
+    const inputValue = 75
+
+    fireEvent.change(slider, { target: { value: inputValue } })
+
+    expect(input).toHaveValue(inputValue.toString())
+
+    fireEvent.change(input, { target: { value: '30' } })
+
+    expect(slider).toHaveValue('30')
+  })
+
+  it('should update inputValue correctly when input value is empty', () => {
+    const input = screen.getByRole('textbox')
+    const inputValue = ''
+
+    fireEvent.change(input, { target: { value: inputValue } })
+
+    expect(input).toHaveValue(inputValue)
+  })
+
+  it('should not update prices when input is blurred and value in input has not changed', () => {
+    const input = screen.getByRole('textbox')
+    const inputValue = min.toString()
+
+    fireEvent.change(input, { target: { value: inputValue } })
+    fireEvent.blur(input)
+
+    expect(input).toHaveValue(inputValue)
+  })
+
+  it('should update prices when input is blurred and input is greater than max value', () => {
+    const input = screen.getByRole('textbox')
+    const inputValue = 101
+
+    fireEvent.change(input, { target: { value: inputValue } })
+    fireEvent.blur(input)
+
+    expect(input).toHaveValue(max.toString())
+  })
+
+  it('should update prices when input is blurred and input is less than min value', () => {
+    const input = screen.getByRole('textbox')
+    const inputValue = -1
+
+    fireEvent.change(input, { target: { value: inputValue } })
+    fireEvent.blur(input)
+
+    expect(input).toHaveValue(min.toString())
+  })
 })

--- a/src/tests/unit/components/slider-with-input/SliderWithInput.spec.jsx
+++ b/src/tests/unit/components/slider-with-input/SliderWithInput.spec.jsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import SliderWithInput from '~/components/slider-with-input/SliderWithInput'
+
+const defaultValue = 0
+const title = 'hello'
+const max = 5
+const min = 0
+const onChange = vi.fn()
+
+// interface SliderWithInputProps {
+//     defaultValue: number
+//     title: string
+//     max: number
+//     min: number
+//     onChange: (value: number) => void
+//   }
+
+describe('SliderWithInput', () => {
+  it('should render correctly', () => {
+    render(
+      <SliderWithInput
+        defaultValue={defaultValue}
+        max={max}
+        min={min}
+        onChange={onChange}
+        title={title}
+      />
+    )
+    const titleElement = screen.getByText(title)
+    expect(titleElement).toBeInTheDocument()
+    screen.logTestingPlaygroundURL()
+  })
+
+  it('should call onChange when slider is moved', () => {})
+
+  it('should update inputValue correctly when input value is empty', () => {})
+  it('should not update prices when input is blurred and value in input has not changed', () => {})
+  it('should update prices when input is blurred and input is greater than max value', () => {})
+})

--- a/src/tests/unit/components/slider-with-input/SliderWithInput.spec.jsx
+++ b/src/tests/unit/components/slider-with-input/SliderWithInput.spec.jsx
@@ -14,6 +14,7 @@ const delay = 500
 describe('SliderWithInput', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    handleChangeMock.mockReset()
     render(
       <SliderWithInput
         defaultValue={defaultValue}
@@ -76,6 +77,7 @@ describe('SliderWithInput', () => {
     fireEvent.blur(input)
 
     expect(input).toHaveValue(inputValue)
+    expect(handleChangeMock).not.toHaveBeenCalled()
   })
 
   it('should update prices when input is blurred and input is greater than max value', () => {


### PR DESCRIPTION
Added tests for the `SliderWithInput` component.
<img width="1470" alt="Screenshot 2025-05-09 at 15 37 45" src="https://github.com/user-attachments/assets/7120d65c-22ad-483d-bcd5-bce16437e58f" />

- Renders correctly  
- Calls `onChange` when the slider is moved  
- Syncs values between the slider and input **(new)**
- Updates input value correctly when it's empty  
- Does not update prices on blur if input hasn't changed  
- Updates prices to `max` if blurred input exceeds max  
- Updates prices to `min` if blurred input is below min  **(new)**

Included two new test cases:
- Syncing slider and input values. 
This behavior is validated by the assertion: 
`expect(input).toHaveValue(inputValue.toString())`
and
`expect(slider).toHaveValue('30')`

- Handling input values less than `min` on blur. The test ensures that if the user enters a value below the min (e.g., -1) and blurs the input, the component updates the input value to the defined min value. 
This behavior is validated by the assertion: 
`expect(input).toHaveValue(min.toString())`

Used `vi.useFakeTimers()`, `vi.advanceTimersByTime(delay)` and `vi.useRealTimers()` for controlling debounce delay. Mocked `onChange` to verify behavior. Ensured test isolation by calling the `mockReset` function before each test.

<img width="788" alt="Screenshot 2025-04-15 at 10 37 01" src="https://github.com/user-attachments/assets/47a6c14b-8050-4207-a783-8f3edd4a63a1" />

<img width="972" alt="Screenshot 2025-04-15 at 10 30 51" src="https://github.com/user-attachments/assets/376a2a16-6e92-4fa2-8f1d-b44caddf07f3" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added a comprehensive test suite for the slider with input component, covering rendering, user interactions, value synchronization, and boundary enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->