### PR TITLE
Bugfix #233 changed text under login button

### DIFF
--- a/src/constants/translations/en/signup.json
+++ b/src/constants/translations/en/signup.json
@@ -7,7 +7,7 @@
   "and": "and",
   "googleButton": "Sign up with Google",
   "continue": "or continue",
-  "haveAccount": "Already have a tutor account?",
+  "haveAccount": "Already have a Space2Study account? Log In!",
   "joinUs": "Login!",
   "confirmEmailTitle": "Your email address needs to be verified",
   "confirmEmailMessage": "We sent a confirmation email to: ",


### PR DESCRIPTION
The text under "Sign Up with Google" button is now "Already have a Space2Study account? Log In!" and is matching to mockup.
before:
![image](https://github.com/user-attachments/assets/aeaa4b10-26dc-4a1c-9640-ead046dd6d80)
after:
Please view it locally. The project's development stage does not allow to access this component yet. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the message for users who already have an account to reference all Space2Study users and include a direct prompt to log in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->