### PR TITLE
#72 create-email-confirmation-pop-up

### DIFF
--- a/src/components/popup-dialog/PopupDialog.tsx
+++ b/src/components/popup-dialog/PopupDialog.tsx
@@ -41,7 +41,7 @@ const PopupDialog: FC<PopupDialogProps> = ({
         onMouseOver={handleMouseOver}
         sx={styles.box}
       >
-        <IconButton sx={styles.icon}>
+        <IconButton onClick={() => closeModalAfterDelay(0)} sx={styles.icon}>
           <CloseIcon />
         </IconButton>
         <Box sx={styles.contentWraper}>{content}</Box>

--- a/src/components/popup-dialog/PopupDialog.tsx
+++ b/src/components/popup-dialog/PopupDialog.tsx
@@ -7,6 +7,7 @@ import { PaperProps } from '@mui/material'
 
 import useBreakpoints from '~/hooks/use-breakpoints'
 import { styles } from '~/components/popup-dialog/PopupDialog.styles'
+import { useModalContext } from '~/context/modal-context'
 
 interface PopupDialogProps {
   content: React.ReactNode
@@ -25,6 +26,7 @@ const PopupDialog: FC<PopupDialogProps> = ({
 
   const handleMouseOver = () => timerId && clearTimeout(timerId)
   const handleMouseLeave = () => timerId && closeModalAfterDelay()
+  const { closeModal } = useModalContext()
 
   return (
     <Dialog
@@ -41,7 +43,7 @@ const PopupDialog: FC<PopupDialogProps> = ({
         onMouseOver={handleMouseOver}
         sx={styles.box}
       >
-        <IconButton onClick={() => closeModalAfterDelay(0)} sx={styles.icon}>
+        <IconButton onClick={closeModal} sx={styles.icon}>
           <CloseIcon />
         </IconButton>
         <Box sx={styles.contentWraper}>{content}</Box>

--- a/src/constants/translations/en/email-modals.json
+++ b/src/constants/translations/en/email-modals.json
@@ -1,5 +1,5 @@
 {
-  "emailConfirm": "Your email has been successfully verified!",
+  "emailConfirm": "Email has been successfully verified!",
   "emailNotConfirm": "Your email address has not been verified!",
   "emailAlreadyConfirm": "Your email address has already been verified!",
   "emailReject": {

--- a/src/containers/email-confirm-modal/EmailConfirmModal.jsx
+++ b/src/containers/email-confirm-modal/EmailConfirmModal.jsx
@@ -5,15 +5,16 @@ import { useCallback } from 'react'
 import { useModalContext } from '~/context/modal-context'
 import { useTranslation } from 'react-i18next'
 import imgReject from '~/assets/img/email-confirmation-modals/not-success-icon.svg'
+import imgSuccess from '~/assets/img/email-confirmation-modals/success-icon.svg'
 import LoginDialog from '~/containers/guest-home-page/login-dialog/LoginDialog'
 import useAxios from '~/hooks/use-axios'
 import { AuthService } from '~/services/auth-service'
 import Loader from '~/components/loader/Loader'
 import ImgTitleDescription from '~/components/img-title-description/ImgTitleDescription'
 
-const EmailConfirmModal = ({ confirmToken, openModal }) => {
+const EmailConfirmModal = ({ confirmToken }) => {
   const { t } = useTranslation()
-  const { closeModal } = useModalContext()
+  const { closeModal, openModal } = useModalContext()
 
   const serviceFunction = useCallback(
     () => AuthService.confirmEmail(confirmToken),
@@ -67,6 +68,25 @@ const EmailConfirmModal = ({ confirmToken, openModal }) => {
           variant='contained'
         >
           {t('common.confirmButton')}
+        </Button>
+      </Box>
+    )
+  }
+
+  if (response) {
+    return (
+      <Box sx={styles.box}>
+        <ImgTitleDescription
+          img={imgSuccess}
+          style={styles}
+          title={t('modals.emailConfirm')}
+        />
+        <Button
+          onClick={openLoginDialog}
+          sx={styles.button}
+          variant='contained'
+        >
+          {t('common.goToName', { name: 'login' })}
         </Button>
       </Box>
     )

--- a/src/pages/guest-home-page/GuestHome.tsx
+++ b/src/pages/guest-home-page/GuestHome.tsx
@@ -25,12 +25,7 @@ const GuestHomePage = () => {
     const resetToken = searchParams.get('resetToken')
     confirmToken &&
       openModal({
-        component: (
-          <EmailConfirmModal
-            confirmToken={confirmToken}
-            openModal={openModal}
-          />
-        )
+        component: <EmailConfirmModal confirmToken={confirmToken} />
       })
     resetToken &&
       openModal({


### PR DESCRIPTION
What was done:
Implemented a modal to display email confirmation result based on the token:

- Success confirmation
![image](https://github.com/user-attachments/assets/9d4301ad-a2ca-43c2-8c92-90a939b87c81)


- Invalid token (BAD_CONFIRM_TOKEN) || Token not found (DOCUMENT_NOT_FOUND)
![image](https://github.com/user-attachments/assets/314e3a84-6cf7-494f-9318-9f80f3988d19)


- Email already confirmed (EMAIL_ALREADY_CONFIRMED)
![image](https://github.com/user-attachments/assets/32402c7b-2b2b-4de9-84da-10db3c0096b5)



Each case includes corresponding icon, title, description, and action (close modal or open login).


- On close button: modal window closes
- On click outside of a modal window: nothing happens as expected




_note_
_Loader component is displayed inside a modal during the loading state. It currently has layout issues — not part of this task and should be addressed separately._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a success state to the email confirmation modal, displaying a confirmation message and success icon when email verification is successful. Users can now proceed directly to the login dialog from this screen.

- **Bug Fixes**
  - The close icon in popup dialogs now immediately closes the modal when clicked.

- **Style**
  - Updated the success message text for email confirmation to improve clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->