### PR TITLE
#244 removed direct closeModal import

### DIFF
--- a/src/components/popup-dialog/PopupDialog.tsx
+++ b/src/components/popup-dialog/PopupDialog.tsx
@@ -8,7 +8,6 @@ import { PaperProps } from '@mui/material'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import { UserRoleEnum } from '~/types'
 import { styles } from '~/components/popup-dialog/PopupDialog.styles'
-import { useModalContext } from '~/context/modal-context'
 
 interface PopupDialogProps {
   content: React.ReactNode
@@ -40,7 +39,6 @@ const PopupDialog: FC<PopupDialogProps> = ({
 
   const handleMouseOver = () => timerId && clearTimeout(timerId)
   const handleMouseLeave = () => timerId && closeModalAfterDelay()
-  const { closeModal } = useModalContext()
 
   return (
     <Dialog


### PR DESCRIPTION
### **Description**
Removed the `closeModal` import from `useModalContext()` in `PopupDialog` so it only uses the `closeModal` prop passed from the parent. 

### **Changes**
- Removed `closeModal` from `useModalContext()`
- `PopupDialog` now only uses the `closeModal` prop

### **Why**
- Prevents confusion between context and prop
- Makes the code easier to maintain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the dialog component to receive close actions as required external properties instead of relying on internal context. This change clarifies how the dialog is controlled and integrated with other parts of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->