### PR TITLE
 Conflict in PopupDialog resolved

### DIFF
--- a/src/components/popup-dialog/PopupDialog.tsx
+++ b/src/components/popup-dialog/PopupDialog.tsx
@@ -50,13 +50,6 @@ const PopupDialog: FC<PopupDialogProps> = ({
     }
   }
 
-  const handleDialogClose = (_event: object, reason: string) => {
-    if (reason === 'backdropClick') {
-      handleClose()
-    }
-    return
-  }
-
   const handleMouseOver = () => timerId && clearTimeout(timerId)
   const handleMouseLeave = () => timerId && closeModalAfterDelay()
 
@@ -67,7 +60,6 @@ const PopupDialog: FC<PopupDialogProps> = ({
       disableRestoreFocus
       fullScreen={isFullScreen ?? isMobile}
       maxWidth='xl'
-      onClose={handleDialogClose}
       open
     >
       <Box


### PR DESCRIPTION
Resolved conflic in the PopupDialog compnent

Removed backdrop click close handler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified dialog behavior by removing custom handling for closing the dialog via backdrop clicks. The dialog no longer responds to backdrop click events for closing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->