### PR TITLE
fixed double rendering problem using useRef hook

### DIFF
--- a/src/hooks/use-axios.tsx
+++ b/src/hooks/use-axios.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { AxiosError } from 'axios'
-
 import { ErrorResponse, ServiceFunction } from '~/types'
 
 export interface UseAxiosProps<
@@ -42,6 +41,8 @@ const useAxios = <
   const [error, setError] = useState<ErrorResponse | null>(null)
   const [loading, setLoading] = useState<boolean>(fetchOnMount)
 
+  const hasFetched = useRef(false)
+
   const fetchData = useCallback(
     async (params?: Params) => {
       try {
@@ -50,12 +51,12 @@ const useAxios = <
         const responseData = transform ? transform(res.data) : res.data
         setResponse(responseData as TransformedResponse)
         setError(null)
-        onResponse && onResponse(responseData as TransformedResponse)
+        onResponse?.(responseData as TransformedResponse)
       } catch (e) {
         const error = e as AxiosError<ErrorResponse>
         if (error.response) {
           setError(error.response.data)
-          onResponseError && onResponseError(error.response.data)
+          onResponseError?.(error.response.data)
         }
       } finally {
         setLoading(false)
@@ -65,10 +66,11 @@ const useAxios = <
   )
 
   useEffect(() => {
-    if (fetchOnMount) {
+    if (fetchOnMount && !hasFetched.current) {
+      hasFetched.current = true
       void fetchData()
     }
-  }, [fetchData, fetchOnMount])
+  }, [fetchOnMount, fetchData])
 
   return { response, error, loading, fetchData }
 }

--- a/src/hooks/use-axios.tsx
+++ b/src/hooks/use-axios.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { AxiosError } from 'axios'
+
 import { ErrorResponse, ServiceFunction } from '~/types'
 
 export interface UseAxiosProps<
@@ -51,12 +52,12 @@ const useAxios = <
         const responseData = transform ? transform(res.data) : res.data
         setResponse(responseData as TransformedResponse)
         setError(null)
-        onResponse?.(responseData as TransformedResponse)
+        onResponse && onResponse(responseData as TransformedResponse)
       } catch (e) {
         const error = e as AxiosError<ErrorResponse>
         if (error.response) {
           setError(error.response.data)
-          onResponseError?.(error.response.data)
+          onResponseError && onResponseError(error.response.data)
         }
       } finally {
         setLoading(false)


### PR DESCRIPTION
Issue: Fixed the problem of fetchData being called twice in useAxios hook when React Strict Mode is enabled. Previously, due to double rendering in Strict Mode, the API request was made twice, causing unnecessary calls and potential redundant state updates.

Changes:

Added the usage of useRef to track the first API call status and prevent it from being re-triggered during the second render in Strict Mode.

Now, the API request is made only once during the component's initial mount.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data fetching behavior to prevent repeated requests on component updates.
- **Refactor**
  - Simplified internal logic for handling response callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->