### PR TITLE
#95 Implement Add photo step

### DIFF
--- a/src/constants/translations/en/become-tutor.json
+++ b/src/constants/translations/en/become-tutor.json
@@ -26,7 +26,7 @@
     "placeholder": "Photo Preview",
     "description": "Please upload a photo that represents you and helps others recognize you.",
     "typeError": "Wrong file type. Only .png/.jpg/.jpeg files are allowed.",
-    "fileSizeError": "Size for one file cannot be more than 10MB."
+    "fileSizeError": "Maximum file size - 10 MB."
   },
   "successMessage": "Success! Your data were added."
 }

--- a/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
+++ b/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.jsx
@@ -1,12 +1,137 @@
-import { Box } from '@mui/material'
+import React, { useState, useEffect, useRef } from 'react'
+import { Box, Typography, Button, IconButton, Tooltip } from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
+import CloudUploadIcon from '@mui/icons-material/CloudUpload'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import { useTranslation } from 'react-i18next'
+import useUpload from '~/hooks/use-upload'
+import DragAndDrop from '~/components/drag-and-drop/DragAndDrop'
 
-import { style } from '~/containers/tutor-home-page/add-photo-step/AddPhotoStep.style'
+import { validationData } from './constants'
+import { style } from './AddPhotoStep.style'
 
 const AddPhotoStep = ({ btnsBox }) => {
+  const { t } = useTranslation()
+  const [files, setFiles] = useState([])
+  const [error, setError] = useState('')
+  const [preview, setPreview] = useState(null)
+  const inputRef = useRef(null)
+
+  useEffect(() => {
+    if (files[0]) {
+      const url = URL.createObjectURL(files[0])
+      setPreview(url)
+      return () => URL.revokeObjectURL(url)
+    }
+    setPreview(null)
+  }, [files])
+
+  const emitter = ({ files: newFiles, error: newError }) => {
+    setFiles(newFiles)
+    setError(newError)
+  }
+
+  const { dragStart, dragLeave, dragDrop, isDrag, addFiles } = useUpload({
+    files,
+    validationData,
+    emitter
+  })
+
+  const hasFile = files.length > 0
+  const maxMb = validationData.maxFileSize / 1_000_000
+
+  const clearFile = () => {
+    setFiles([])
+    setError('')
+  }
+
+  const handleRootClick = () => {
+    inputRef.current?.click()
+  }
+
   return (
     <Box sx={style.root}>
-      AddPhoto step
-      {btnsBox}
+      <DragAndDrop
+        emitter={emitter}
+        initialState={files}
+        isDrag={isDrag}
+        onClick={handleRootClick}
+        onDragLeave={dragLeave}
+        onDragStart={dragStart}
+        onDrop={dragDrop}
+        style={{
+          root: style.imgContainer,
+          uploadBox: style.uploadBox,
+          activeDrag: style.activeDrag
+        }}
+        validationData={validationData}
+      >
+        {hasFile ? (
+          <Box sx={{ position: 'relative', width: '100%' }}>
+            <Box
+              alt={t('becomeTutor.photo.imageAlt')}
+              component='img'
+              src={preview}
+              sx={style.img}
+            />
+            <Tooltip title='Clear'>
+              <IconButton
+                aria-label='Clear photo'
+                onClick={clearFile}
+                size='small'
+                sx={style.clearButton}
+              >
+                <CloseIcon fontSize='small' />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        ) : (
+          <Typography>{t('becomeTutor.photo.placeholder')}</Typography>
+        )}
+      </DragAndDrop>
+
+      <Box sx={style.rightColumn}>
+        <Typography sx={style.description}>
+          {t('becomeTutor.photo.description')}
+        </Typography>
+
+        <Box sx={style.uploadControl}>
+          <Button
+            component='label'
+            startIcon={<CloudUploadIcon />}
+            sx={style.uploadButton}
+            variant='outlined'
+          >
+            {hasFile ? files[0].name : t('becomeTutor.photo.button')}
+            <input
+              accept={validationData.filesTypes.join(',')}
+              hidden
+              onChange={addFiles}
+              ref={inputRef}
+              type='file'
+            />
+          </Button>
+          {hasFile && <CheckCircleIcon color='success' sx={style.checkIcon} />}
+        </Box>
+
+        <Typography
+          color='text.secondary'
+          sx={style.fileSize}
+          variant='caption'
+        >
+          {hasFile
+            ? `${(files[0].size / 1_000_000).toFixed(1)} MB (max ${maxMb} MB)`
+            : `Max ${maxMb} MB`}
+        </Typography>
+
+        {error && (
+          <Typography color='error' sx={style.errorText}>
+            {t(error)}
+          </Typography>
+        )}
+
+        <Box sx={style.navButtons}>{btnsBox}</Box>
+      </Box>
     </Box>
   )
 }

--- a/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.style.js
+++ b/src/containers/tutor-home-page/add-photo-step/AddPhotoStep.style.js
@@ -5,24 +5,9 @@ export const style = {
     display: 'flex',
     justifyContent: 'space-between',
     gap: '40px',
-    height: { sm: '485px' },
-    paddingBottom: { sm: '210px', md: '0px' },
     ...fadeAnimation
   },
-  img: {
-    width: '100%',
-    borderRadius: '20px',
-    mt: { xs: '20px', md: '0px' }
-  },
   imgContainer: {
-    display: 'flex',
-    alignItems: 'center',
-    maxWidth: '440px',
-    width: '100%',
-    flex: 1,
-    pb: { xs: '16px', sm: '26px', md: '52px' }
-  },
-  uploadBox: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
@@ -32,37 +17,61 @@ export const style = {
     border: '2px dashed',
     borderColor: 'primary.200',
     borderRadius: '20px',
-    mt: { xs: '20px', md: '0px' }
+    mt: { xs: '20px', md: '0px' },
+    cursor: 'pointer'
+  },
+  uploadBox: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'column',
+    width: '100%',
+    height: '100%'
   },
   activeDrag: {
-    border: '2px primary',
     borderColor: 'primary.900'
   },
-  rigthBox: {
+  img: {
+    width: '100%',
+    borderRadius: '20px',
+    mt: { xs: '20px', md: '0px' }
+  },
+  clearButton: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    backgroundColor: 'rgba(255,255,255,0.8)',
+    '&:hover': {
+      backgroundColor: 'rgba(255,255,255,1)'
+    }
+  },
+  rightColumn: {
+    flex: 1,
     display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'space-between',
-    maxWidth: '432px',
-    m: { md: 0, xs: '0 auto' },
-    pt: 0,
-    pb: { xs: '30px', sm: '0' }
+    flexDirection: 'column'
   },
   description: {
-    mb: '20px'
+    mb: 1
   },
-  fileUploader: {
-    button: {
-      textAlign: 'center'
-    },
-    root: {
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'space-around',
-      border: '1px solid',
-      borderColor: 'primary.200',
-      borderRadius: '5px',
-      maxWidth: '270px',
-      overflow: 'auto'
-    }
+  uploadControl: {
+    display: 'flex',
+    alignItems: 'center',
+    mb: 1
+  },
+  uploadButton: {
+    textTransform: 'none'
+  },
+  checkIcon: {
+    ml: 1,
+    fontSize: '1.5rem'
+  },
+  fileSize: {
+    mb: 2
+  },
+  errorText: {
+    mb: 2
+  },
+  navButtons: {
+    mt: 'auto'
   }
 }


### PR DESCRIPTION
<img width="931" alt="pr" src="https://github.com/user-attachments/assets/6e287f9e-1d18-491f-8a15-db8e4bb885e3" />
Summary
This PR enhances the “Add Photo” step by fully implementing the acceptance criteria for file selection and preview, plus adding a clear button to reset the chosen file.

Changes:
- Click-to-upload: clicking anywhere in the drop zone (or on the “Upload” button) now opens the file picker.
- Drag-and-drop: dragging a file over the dashed container highlights it; dropping loads and validates the file.
- Preview: once loaded, the image is displayed in the left block with proper cleanup of its blob: URL on unmount.
- Clear button: an overlay “×” icon appears on the preview to let users reset the file and error state.
- Styles: moved clear-button styles into AddPhotoStep.style.js.
- JSX props sorted: all component props are now in alphabetical order to satisfy our linting rules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a fully functional photo upload step with drag-and-drop support, image preview, and file validation in the tutor onboarding flow.
  - Added clear button to remove selected images and improved user feedback for file size and validation errors.
- **Style**
  - Refined layout and styling for the photo upload step, including enhanced drag-and-drop area, image preview, and clearer error messages.
- **Bug Fixes**
  - Improved and clarified error message for file size limits during photo uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->