### PR TITLE
#252: Add input limit error display

### DIFF
--- a/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.jsx
+++ b/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.jsx
@@ -1,6 +1,4 @@
-import { useState } from 'react'
 import Box from '@mui/material/Box'
-
 import { Typography, TextField, MenuItem, Stack } from '@mui/material'
 import { styles } from '~/containers/tutor-home-page/general-info-step/GeneralInfoStep.styles'
 import { useTranslation } from 'react-i18next'
@@ -18,13 +16,12 @@ const GeneralInfoStep = ({ btnsBox }) => {
   const { data: contextData } = stepData.generalInfo
   const { firstName, lastName, city, country, professionalSummary } =
     contextData
-  const [realValue, setRealValue] = useState(professionalSummary)
-  const [hasError, setHasError] = useState(false)
 
   const {
     handleBlur,
     handleInputChange,
-    errors: useFormErrors
+    errors: useFormErrors,
+    handleErrors
   } = useForm({
     initialValues: contextData,
     validations: {
@@ -46,6 +43,10 @@ const GeneralInfoStep = ({ btnsBox }) => {
     handleBlur('firstName')(e)
   }
 
+  function handleProfessionalSummaryBlur(e) {
+    handleBlur('professionalSummary')(e)
+  }
+
   function handleLastNameChange(e) {
     handleStepData('generalInfo', { ...contextData, lastName: e.target.value })
     handleInputChange('lastName')(e)
@@ -62,22 +63,19 @@ const GeneralInfoStep = ({ btnsBox }) => {
   function handleCitySelect(e) {
     handleStepData('generalInfo', { ...contextData, city: e.target.value })
   }
+
   const handleProfessionalSummaryChange = (e) => {
     const newValue = e.target.value
-    setRealValue(newValue)
-    if (newValue.length > 200) {
-      setHasError(true)
-    } else {
-      setHasError(false)
-      handleStepData('generalInfo', {
-        ...contextData,
-        professionalSummary: newValue
-      })
-    }
-  }
+    handleStepData('generalInfo', {
+      ...contextData,
+      professionalSummary: newValue
+    })
 
-  function handleProfessionalSummaryBlur(e) {
-    handleBlur('professionalSummary')(e)
+    if (newValue.length > 200) {
+      handleErrors('professionalSummary', 'common.errorMessages.longText')
+    } else {
+      handleErrors('professionalSummary', '')
+    }
   }
 
   return (
@@ -141,13 +139,14 @@ const GeneralInfoStep = ({ btnsBox }) => {
               <MenuItem value='Porto'>Porto</MenuItem>
             </TextField>
           </Stack>
+
           <TextField
-            error={hasError}
+            error={useFormErrors.professionalSummary}
             fullWidth
             helperText={
-              hasError
-                ? t('common.errorMessages.longText')
-                : `${realValue.length}/200`
+              useFormErrors.professionalSummary
+                ? t(useFormErrors.professionalSummary)
+                : `${professionalSummary.length}/200`
             }
             label={t('becomeTutor.generalInfo.textFieldLabel')}
             maxLength={200}
@@ -156,7 +155,7 @@ const GeneralInfoStep = ({ btnsBox }) => {
             onChange={handleProfessionalSummaryChange}
             rows={4}
             sx={styles.textArea}
-            value={realValue}
+            value={professionalSummary}
           />
         </Stack>
 

--- a/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.jsx
+++ b/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.jsx
@@ -1,8 +1,7 @@
+import { useState } from 'react'
 import Box from '@mui/material/Box'
 
 import { Typography, TextField, MenuItem, Stack } from '@mui/material'
-import AppTextArea from '~/components/app-text-area/AppTextArea'
-
 import { styles } from '~/containers/tutor-home-page/general-info-step/GeneralInfoStep.styles'
 import { useTranslation } from 'react-i18next'
 
@@ -19,6 +18,8 @@ const GeneralInfoStep = ({ btnsBox }) => {
   const { data: contextData } = stepData.generalInfo
   const { firstName, lastName, city, country, professionalSummary } =
     contextData
+  const [realValue, setRealValue] = useState(professionalSummary)
+  const [hasError, setHasError] = useState(false)
 
   const {
     handleBlur,
@@ -61,12 +62,18 @@ const GeneralInfoStep = ({ btnsBox }) => {
   function handleCitySelect(e) {
     handleStepData('generalInfo', { ...contextData, city: e.target.value })
   }
-
-  function handleProfessionalSummaryChange(e) {
-    handleStepData('generalInfo', {
-      ...contextData,
-      professionalSummary: e.target.value
-    })
+  const handleProfessionalSummaryChange = (e) => {
+    const newValue = e.target.value
+    setRealValue(newValue)
+    if (newValue.length > 200) {
+      setHasError(true)
+    } else {
+      setHasError(false)
+      handleStepData('generalInfo', {
+        ...contextData,
+        professionalSummary: newValue
+      })
+    }
   }
 
   function handleProfessionalSummaryBlur(e) {
@@ -134,15 +141,22 @@ const GeneralInfoStep = ({ btnsBox }) => {
               <MenuItem value='Porto'>Porto</MenuItem>
             </TextField>
           </Stack>
-
-          <AppTextArea
+          <TextField
+            error={hasError}
             fullWidth
+            helperText={
+              hasError
+                ? t('common.errorMessages.longText')
+                : `${realValue.length}/200`
+            }
             label={t('becomeTutor.generalInfo.textFieldLabel')}
             maxLength={200}
+            multiline
             onBlur={handleProfessionalSummaryBlur}
             onChange={handleProfessionalSummaryChange}
+            rows={4}
             sx={styles.textArea}
-            value={professionalSummary}
+            value={realValue}
           />
         </Stack>
 


### PR DESCRIPTION
I added an error message when the character limit is exceeded.
<img width="469" alt="Знімок екрана 2025-04-24 о 12 41 05" src="https://github.com/user-attachments/assets/bf8e57bf-562b-431c-9f43-944166fb5ea2" />

The input is restored once the user deletes extra characters.
<img width="456" alt="Знімок екрана 2025-04-24 о 12 41 16" src="https://github.com/user-attachments/assets/8141678c-22a8-45f6-921a-8235ef30ad9d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added real-time character count and input length validation for the professional summary field, with immediate user feedback if the 200-character limit is exceeded.

- **Bug Fixes**
  - Improved handling of input updates to prevent saving summaries that exceed the character limit.

- **Style**
  - Updated the professional summary input to use a Material-UI text field for a more consistent appearance and enhanced usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->