### PR TITLE
#257: added loader to the sign up button if async request is in progress

### DIFF
--- a/src/containers/guest-home-page/registration-dialog/RegistrationDialog.tsx
+++ b/src/containers/guest-home-page/registration-dialog/RegistrationDialog.tsx
@@ -1,7 +1,7 @@
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 
-import { FC } from 'react'
+import { FC, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { useModalContext } from '~/context/modal-context'
@@ -29,6 +29,7 @@ const RegistrationDialog: FC<RegistrationDialogProps> = ({ defaultRole }) => {
   const { t } = useTranslation()
   const { closeModal, openModal } = useModalContext()
   const [signUp] = useSignUpMutation()
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const validateEmail = (email: string): string | undefined => {
     if (!email) return 'common.errorMessages.emptyField'
@@ -86,12 +87,14 @@ const RegistrationDialog: FC<RegistrationDialogProps> = ({ defaultRole }) => {
       confirmPassword: validateConfirmPassword
     },
     onSubmit: async () => {
+      setIsSubmitting(true)
       console.log('Form submitted with values:', data)
       try {
         const response = await signUp(data).unwrap()
         console.log('Registration succesful!', response)
         closeModal()
-        
+        setIsSubmitting(false)
+
         openModal({
           component: (
             <EmailInfoPopup email={data.email} onClose={closeModal} open />
@@ -99,6 +102,7 @@ const RegistrationDialog: FC<RegistrationDialogProps> = ({ defaultRole }) => {
         })
       } catch (e) {
         console.log('Something went wrong', e)
+        setIsSubmitting(false)
       }
       return Promise.resolve()
     }
@@ -125,6 +129,7 @@ const RegistrationDialog: FC<RegistrationDialogProps> = ({ defaultRole }) => {
             handleBlur={handleBlur}
             handleChange={handleInputChange}
             handleSubmit={handleFormSubmit}
+            isSubmitting={isSubmitting}
           />
         </Box>
         <GoogleLogin

--- a/src/containers/guest-home-page/registration-dialog/RegistrationDialog.tsx
+++ b/src/containers/guest-home-page/registration-dialog/RegistrationDialog.tsx
@@ -94,7 +94,6 @@ const RegistrationDialog: FC<RegistrationDialogProps> = ({ defaultRole }) => {
         console.log('Registration succesful!', response)
         closeModal()
         setIsSubmitting(false)
-
         openModal({
           component: (
             <EmailInfoPopup email={data.email} onClose={closeModal} open />

--- a/src/containers/guest-home-page/registration-form/RegistrationForm.tsx
+++ b/src/containers/guest-home-page/registration-form/RegistrationForm.tsx
@@ -12,6 +12,7 @@ import { useModalContext } from '~/context/modal-context'
 import AppTextField from '~/components/app-text-field/AppTextField'
 import AppButton from '~/components/app-button/AppButton'
 import { styles } from '~/containers/guest-home-page/registration-form/RegistrationForm.styles'
+import Loader from '~/components/loader/Loader'
 
 type FormFields =
   | 'email'
@@ -22,6 +23,7 @@ type FormFields =
   | 'confirmPassword'
 
 interface RegistrationFormProps {
+  isSubmitting: boolean
   handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void
   handleChange: (
     field: FormFields
@@ -48,6 +50,7 @@ interface RegistrationFormProps {
 }
 
 const RegistrationForm: React.FC<RegistrationFormProps> = ({
+  isSubmitting,
   handleSubmit,
   handleChange,
   handleBlur,
@@ -203,11 +206,15 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({
         }
       />
       <AppButton
-        disabled={!isFormComplete}
+        disabled={!isFormComplete || isSubmitting}
         sx={styles.loginButton}
         type='submit'
       >
-        {t('common.labels.signup')}
+        {isSubmitting ? (
+          <Loader size={20} sx={{ opacity: '0.6' }} />
+        ) : (
+          t('common.labels.signup')
+        )}
       </AppButton>
     </Box>
   )


### PR DESCRIPTION
📄 Pull Request Description
🔧 What was done:
Introduced isSubmitting state in RegistrationDialog to handle form submission status

Passed isSubmitting as a prop to RegistrationForm

Displayed a <Loader /> inside the submit button while submitting

Disabled the submit button during the submission to prevent multiple requests

🎯 Why:
Previously, the form submit button remained active during submission, allowing duplicate requests and giving no visual feedback to the user.

🖼 Before / After (during form submit):
Before:
![image](https://github.com/user-attachments/assets/ab829635-d200-4f0e-9fc8-2071915c1d47)



After:
![image](https://github.com/user-attachments/assets/721e4c11-1098-4d60-87d5-dad946d7dd1a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The registration form now displays a loading spinner and disables the submit button while your registration is being processed, preventing multiple submissions and providing clearer feedback during sign-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->