### PR TITLE
Added validation to nameField to check for empty fields

### DIFF
--- a/src/utils/validations/common.ts
+++ b/src/utils/validations/common.ts
@@ -7,6 +7,9 @@ interface Validations {
 
 const validations: Validations = {
   nameField: (value) => {
+    if (value.trim().length === 0) {
+      return 'common.errorMessages.emptyField'
+    }
     if (value.length > 30) {
       return 'common.errorMessages.nameLength'
     }


### PR DESCRIPTION
Added validation to `nameField` to ensure that fields are not empty or contain only whitespace. This enhancement ensures users enter valid names and prevents submission of blank fields.

```js
if (value.trim().length === 0) {
  return 'common.errorMessages.emptyField'
}
```

The function checks whether the field value is empty or consists solely of whitespace. It trims leading and trailing spaces using `trim()` and checks if the resulting string's length is zero. If so, it returns the error message `'common.errorMessages.emptyField'`, indicating that the field cannot be left blank and must contain valid input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for name fields by displaying an explicit error message when the input is left empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->