### PR TITLE
Implement category item card

### DIFF
--- a/src/components/app-card/AppCard.styles.ts
+++ b/src/components/app-card/AppCard.styles.ts
@@ -6,7 +6,11 @@ import {
 export const styles = {
   container: (isClickable: boolean) => ({
     display: 'flex',
-    padding: '20px 30px',
+    padding: '25px 33px 25px 32px',
+    maxWidth: '360px',
+    maxHeight: '112px',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
     textDecoration: 'none',
     backgroundColor: 'basic.white',
     boxShadow: commonShadow,

--- a/src/components/card-with-link/CardWithLink.tsx
+++ b/src/components/card-with-link/CardWithLink.tsx
@@ -6,11 +6,12 @@ import TitleWithDescription from '~/components/title-with-description/TitleWithD
 
 import { styles } from '~/components/card-with-link/CardWithLink.styles'
 
-interface CardWithLinkProps {
+export interface CardWithLinkProps {
+  _id: string
   img: string
   title: string
   description: string
-  link: string
+  link?: string
 }
 
 const CardWithLink: FC<CardWithLinkProps> = ({

--- a/src/components/cards-list/CardsList.tsx
+++ b/src/components/cards-list/CardsList.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactElement } from 'react'
+import { FC } from 'react'
 import Box from '@mui/material/Box'
 
 import AppButton from '~/components/app-button/AppButton'
@@ -6,10 +6,13 @@ import Loader from '~/components/loader/Loader'
 
 import { styles } from '~/components/cards-list/CardsList.styles'
 import { SizeEnum, ButtonVariantEnum } from '~/types'
+import CardWithLink, {
+  CardWithLinkProps
+} from '~/components/card-with-link/CardWithLink'
 
 interface CardsListProps {
   btnText: string
-  cards: ReactElement[]
+  cards: CardWithLinkProps[]
   isExpandable?: boolean
   loading?: boolean
   onClick: () => void
@@ -29,7 +32,11 @@ const CardsList: FC<CardsListProps> = ({
           <Loader pageLoad size={50} />
         </Box>
       ) : (
-        <Box sx={styles.cardsContainer}>{cards}</Box>
+        <Box sx={styles.cardsContainer}>
+          {cards.map((card, index) => (
+            <CardWithLink key={index} {...card} />
+          ))}
+        </Box>
       )}
 
       {isExpandable && (

--- a/src/pages/categories/Categories.tsx
+++ b/src/pages/categories/Categories.tsx
@@ -1,7 +1,39 @@
 import PageWrapper from '~/components/page-wrapper/PageWrapper'
+import CardsList from '~/components/cards-list/CardsList'
+import { CardWithLinkProps } from '~/components/card-with-link/CardWithLink'
+
+const mockCards: CardWithLinkProps[] = [
+  {
+    _id: '64884fedfdc2d1a130c24ade',
+    img: '/icons/design.svg',
+    title: 'Design',
+    description: '24 offers'
+  },
+  {
+    _id: '64884fedfdc2d1a130c24adf',
+    img: '/icons/development.svg',
+    title: 'Development',
+    description: '36 offers'
+  }
+]
 
 const Categories = () => {
-  return <PageWrapper>Categories</PageWrapper>
+  const handleLoadMore = () => {}
+
+  return (
+    <PageWrapper>
+      <CardsList
+        btnText='Load more'
+        cards={mockCards.map((card) => ({
+          ...card,
+          link: `/categories/subjects?categoryId=${card._id}`
+        }))}
+        isExpandable={false}
+        loading={false}
+        onClick={handleLoadMore}
+      />
+    </PageWrapper>
+  )
 }
 
 export default Categories


### PR DESCRIPTION
1. Implemented a card with an icon, title, description (number of offers), and a link for redirection based on the category ID when clicked.
2. I also added/changed some styles to match the Figma design.

> I don’t implemented the handleLoadMore function yet, since the fetch logic is still to be added.

> Currently using mocked data to verify the correctness of the styles, pagination, and layout before integrating the actual fetch logic.
<img width="692" alt="Знімок екрана 2025-04-30 о 17 39 58" src="https://github.com/user-attachments/assets/4e36531b-12b3-4521-a5c4-3b4dc3f4b939" />

(left - hovered, right - normal)

**The full fetch logic will be implemented in the next task** — [Implement list of categories block](https://github.com/orgs/Space2Study-UA-1355-01/projects/1/views/1?pane=issue&itemId=105212945&issue=Space2Study-UA-1355-01%7CIssues%7C91)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Categories page now displays a list of cards with images, titles, and descriptions, along with a "Load more" button.

- **Improvements**
  - Card list rendering is now driven by card data rather than pre-constructed elements, allowing for more flexible and dynamic content.
  - Card layout and sizing have been refined for better visual consistency and alignment.

- **API Changes**
  - Card data now requires an `_id` property and supports an optional link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->