### PR TITLE
#88 Implement create offer/request block

### DIFF
--- a/src/components/title-block/TitleBlock.tsx
+++ b/src/components/title-block/TitleBlock.tsx
@@ -30,7 +30,7 @@ const TitleBlock: FC<TitleBlockProps> = ({
     <Box className='section' sx={{ ...styles.container, ...style }}>
       <Box sx={styles.info}>
         <TitleWithDescription
-          description={t(`${translationKey}.description`)}
+          description={t(`${translationKey}.description.${userRole}`)}
           style={styles.titleWithDescription}
           title={t(`${translationKey}.title.${userRole}`)}
         />

--- a/src/constants/translations/en/find-offer-page.json
+++ b/src/constants/translations/en/find-offer-page.json
@@ -4,8 +4,14 @@
       "tutor": "Student for private lessons",
       "student": "Tutor for private lessons"
     },
-    "description": "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.",
-    "button": "Create request"
+    "description": {
+      "tutor": "Start building your tutoring business by creating your offer. Select the options that best describes your expertise.",
+      "student": "Find the perfect tutor for your needs by creating a request. Select the options that best describe what you`re looking for."
+    },
+    "button": {
+      "tutor": "Create request",
+      "student": "Create offer"
+    }
   },
   "titleWithDescription": {
     "title": "Explore Offers",

--- a/src/containers/find-offer/offer-request-block/OfferRequestBlock.tsx
+++ b/src/containers/find-offer/offer-request-block/OfferRequestBlock.tsx
@@ -1,19 +1,25 @@
 import { useTranslation } from 'react-i18next'
 
+import { useAppSelector } from '~/hooks/use-redux'
 import TitleBlock from '~/components/title-block/TitleBlock'
 import icon from '~/assets/img/find-offer/subject_icon.png'
 import AppButton from '~/components/app-button/AppButton'
 import useBreakpoints from '~/hooks/use-breakpoints'
-import { useDrawer } from '~/hooks/use-drawer'
+//import { useDrawer } from '~/hooks/use-drawer'
 import { translationKey } from '~/containers/find-offer/constants'
 
 const OfferRequestBlock = () => {
   const { t } = useTranslation()
   const { isMobile } = useBreakpoints()
-  const { openDrawer } = useDrawer()
+  //const { openDrawer } = useDrawer()
+  const { userRole } = useAppSelector((state) => state.appMain) as {
+    userRole: 'tutor' | 'student'
+  }
 
+  //placeholder until the "Create request/offer" modal is ready
   const handleOpenDrawer = () => {
-    openDrawer()
+    //openDrawer()
+    alert('Modal is not implement yet')
   }
 
   return (
@@ -23,7 +29,7 @@ const OfferRequestBlock = () => {
         onClick={handleOpenDrawer}
         sx={{ py: '14px' }}
       >
-        {t(`${translationKey}.button`)}
+        {t(`${translationKey}.button.${userRole}`)}
       </AppButton>
     </TitleBlock>
   )

--- a/src/pages/categories/Categories.tsx
+++ b/src/pages/categories/Categories.tsx
@@ -1,7 +1,12 @@
 import PageWrapper from '~/components/page-wrapper/PageWrapper'
+import OfferRequestBlock from '~/containers/find-offer/offer-request-block/OfferRequestBlock'
 
 const Categories = () => {
-  return <PageWrapper>Categories</PageWrapper>
+  return (
+    <PageWrapper>
+      <OfferRequestBlock />
+    </PageWrapper>
+  )
 }
 
 export default Categories

--- a/src/pages/find-offers/FindOffers.tsx
+++ b/src/pages/find-offers/FindOffers.tsx
@@ -1,7 +1,12 @@
 import PageWrapper from '~/components/page-wrapper/PageWrapper'
+import OfferRequestBlock from '~/containers/find-offer/offer-request-block/OfferRequestBlock'
 
 const FindOffers = () => {
-  return <PageWrapper>Find offers</PageWrapper>
+  return (
+    <PageWrapper>
+      <OfferRequestBlock />
+    </PageWrapper>
+  )
 }
 
 export default FindOffers


### PR DESCRIPTION
Description
Adds the OfferRequestBlock component to the Subjects, FindOffers, and Categories pages, which:

Displays the title “Tutors for private lessons” or “Students for private lessons” depending on the user’s role (tutor/student).

Shows the button “Create request” or “Create offer” depending on the same role.

Currently triggers an alert(...) stub instead of a real modal when clicked.

Also updates the translations in find-offer-page.json to support object keys for both description and button.

<img width="902" alt="PR1" src="https://github.com/user-attachments/assets/7d115124-a878-4833-b83e-55bf189c7b61" />
<img width="912" alt="PR2" src="https://github.com/user-attachments/assets/fed04ff6-bd1b-483a-88ee-4938eb20dda9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced role-specific descriptions and button labels for offer requests, providing tailored guidance and actions for tutors and students.
  - Updated the offer request block to display content based on the user's role.
  - Added the offer request block to the Categories and Find Offers pages for enhanced user interaction.

- **Bug Fixes**
  - Adjusted translation logic to ensure descriptions and button labels reflect the user's role.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->