### PR TITLE
Implement list of categories block

### DIFF
--- a/src/components/card-with-link/CardWithLink.styles.ts
+++ b/src/components/card-with-link/CardWithLink.styles.ts
@@ -1,10 +1,16 @@
 export const styles = {
   img: {
     width: '100%',
+    height: '100%',
     alignSelf: 'center',
     mr: '24px',
     maxWidth: '62px',
-    maxHeight: '62px'
+    maxHeight: '62px',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: '12px',
+    padding: '4px'
   },
   titleWithDescription: {
     wrapper: {
@@ -15,7 +21,7 @@ export const styles = {
       textAlign: 'start'
     },
     title: {
-      whiteSpace: 'nowrap',
+      whiteSpace: 'wrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       color: 'basic.black',

--- a/src/components/card-with-link/CardWithLink.tsx
+++ b/src/components/card-with-link/CardWithLink.tsx
@@ -5,28 +5,41 @@ import AppCard from '~/components/app-card/AppCard'
 import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
 
 import { styles } from '~/components/card-with-link/CardWithLink.styles'
+import { CategoryAppearance } from '~/types'
 
 export interface CardWithLinkProps {
   _id: string
-  img: string
-  title: string
+  icon: React.ElementType
+  appearance: CategoryAppearance
+  name: string
   description: string
   link?: string
 }
 
 const CardWithLink: FC<CardWithLinkProps> = ({
-  img,
-  title,
+  icon,
+  name,
   description,
-  link
+  link,
+  appearance
 }) => {
+  const IconComponent = icon
   return (
     <AppCard link={link}>
-      <Box alt='item image' component='img' src={img} sx={styles.img} />
+      <Box
+        sx={{
+          ...styles.img,
+          backgroundColor: appearance.color
+        }}
+      >
+        <IconComponent
+          sx={{ width: '32px', height: '32px', color: appearance.icon }}
+        />
+      </Box>
       <TitleWithDescription
         description={description}
         style={styles.titleWithDescription}
-        title={title}
+        title={name}
       />
     </AppCard>
   )

--- a/src/components/category-card/Icons.tsx
+++ b/src/components/category-card/Icons.tsx
@@ -1,0 +1,27 @@
+import TagIcon from '@mui/icons-material/Tag'
+import MusicNoteIcon from '@mui/icons-material/MusicNote'
+import TranslateIcon from '@mui/icons-material/Translate'
+import LanguageIcon from '@mui/icons-material/Language'
+import DesignServicesIcon from '@mui/icons-material/DesignServices'
+import AttachMoneyIcon from '@mui/icons-material/AttachMoney'
+import ColorLensIcon from '@mui/icons-material/ColorLens'
+import ScienceIcon from '@mui/icons-material/Science'
+import NightlightIcon from '@mui/icons-material/Nightlight'
+import FactCheckIcon from '@mui/icons-material/FactCheck'
+import BiotechIcon from '@mui/icons-material/Biotech'
+import ComputerIcon from '@mui/icons-material/Computer'
+
+export const CategoryIconsMap: Record<string, React.ElementType> = {
+  Mathematics: TagIcon,
+  History: LanguageIcon,
+  Music: MusicNoteIcon,
+  Languages: TranslateIcon,
+  Design: DesignServicesIcon,
+  Finances: AttachMoneyIcon,
+  Painting: ColorLensIcon,
+  Chemistry: ScienceIcon,
+  Astronomy: NightlightIcon,
+  Audit: FactCheckIcon,
+  Biology: BiotechIcon,
+  'Computer science': ComputerIcon
+}

--- a/src/pages/categories/Categories.tsx
+++ b/src/pages/categories/Categories.tsx
@@ -99,14 +99,14 @@ const Categories = () => {
   useEffect(() => {
     setCards([])
     setPage(1)
-    fetchCategories(1)
+    void fetchCategories(1)
   }, [fetchCategories, selectedCategoryId])
 
   const handleLoadMore = () => {
     if (!hasMore || loading) return
     const nextPage = page + 1
     setPage(nextPage)
-    fetchCategories(nextPage)
+    void fetchCategories(nextPage)
   }
 
   const showLoadMoreButton = !selectedCategoryId && hasMore && cards.length > 0

--- a/src/pages/categories/Categories.tsx
+++ b/src/pages/categories/Categories.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router-dom'
 
@@ -8,8 +8,9 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import { styles } from '~/pages/categories/Categories.styles'
 import { authRoutes } from '~/router/constants/authRoutes'
 import useCategoriesNames from '~/hooks/use-categories-names'
+import { axiosClient } from '~/plugins/axiosClient'
 
-import { CategoryNameInterface, SizeEnum } from '~/types'
+import { CategoryNameInterface, SizeEnum, CategoryInterface } from '~/types'
 
 import TitleWithDescription from '~/components/title-with-description/TitleWithDescription'
 import PageWrapper from '~/components/page-wrapper/PageWrapper'
@@ -17,14 +18,98 @@ import SearchAutocomplete from '~/components/search-autocomplete/SearchAutocompl
 import DirectionLink from '~/components/direction-link/DirectionLink'
 import AppToolbar from '~/components/app-toolbar/AppToolbar'
 import OfferRequestBlock from '~/containers/find-offer/offer-request-block/OfferRequestBlock'
+import CardsList from '~/components/cards-list/CardsList'
+import { CardWithLinkProps } from '~/components/card-with-link/CardWithLink'
+import { CategoryIconsMap } from '~/components/category-card/Icons'
 
 import { getNameById, getIdByName } from '~/utils/helper-functions'
+
+const getAccessTokenFromCookie = () => {
+  const match = document.cookie.match(/(?:^|; )access_token=([^;]*)/)
+  return match ? match[1] : ''
+}
+
+const LIMIT = 6
+const apiPath = import.meta.env.VITE_API_BASE_PATH
 
 const Categories = () => {
   const { t } = useTranslation()
   const [searchParams, setSearchParams] = useSearchParams()
   const selectedCategoryId = searchParams.get('id') || ''
   const [isFetched, setIsFetched] = useState(false)
+
+  const [cards, setCards] = useState<CardWithLinkProps[]>([])
+  const [page, setPage] = useState(1)
+  const [loading, setLoading] = useState(false)
+  const [hasMore, setHasMore] = useState(true)
+
+  const fetchCategories = useCallback(
+    async (pageToLoad = 1) => {
+      setLoading(true)
+      try {
+        const headers = {
+          Authorization: `Bearer ${getAccessTokenFromCookie()}`
+        }
+
+        let data: CategoryInterface[] = []
+        if (selectedCategoryId) {
+          const res = await axiosClient.get<CategoryInterface>(
+            `${apiPath}/categories/${selectedCategoryId}`,
+            { headers }
+          )
+          data = [res.data]
+          setHasMore(false)
+        } else {
+          const res = await axiosClient.get<{
+            data: CategoryInterface[]
+            totalPages: number
+          }>(`${apiPath}/categories?page=${pageToLoad}&limit=${LIMIT}`, {
+            headers
+          })
+          data = res.data.data
+          const isLastPage = pageToLoad >= res.data.totalPages
+          setHasMore(!isLastPage)
+        }
+
+        const transformed = data.map(
+          (card: CategoryInterface): CardWithLinkProps => ({
+            _id: card._id,
+            name: card.name,
+            icon: CategoryIconsMap[card.name],
+            description: `${Number(card.totalOffers)} Offers`,
+            link: `${apiPath}/categories/${card._id}/subjects/names`,
+            appearance: card.appearance
+          })
+        )
+
+        setCards((prev) =>
+          pageToLoad === 1 || selectedCategoryId
+            ? transformed
+            : [...prev, ...transformed]
+        )
+      } catch (error) {
+        console.error('Failed to fetch categories:', error)
+      } finally {
+        setLoading(false)
+      }
+    },
+    [selectedCategoryId]
+  )
+
+  useEffect(() => {
+    setCards([])
+    setPage(1)
+    fetchCategories(1)
+  }, [fetchCategories, selectedCategoryId])
+
+  const handleLoadMore = () => {
+    if (!hasMore || loading) return
+    const nextPage = page + 1
+    setPage(nextPage)
+    fetchCategories(nextPage)
+  }
+
+  const showLoadMoreButton = !selectedCategoryId && hasMore && cards.length > 0
 
   const transform: (
     data: CategoryNameInterface[] | { data: CategoryNameInterface[] }
@@ -104,6 +189,13 @@ const Categories = () => {
           }}
         />
       </AppToolbar>
+      <CardsList
+        btnText={t('categoriesPage.viewMore')}
+        cards={cards}
+        isExpandable={showLoadMoreButton}
+        loading={loading}
+        onClick={handleLoadMore}
+      />
     </PageWrapper>
   )
 }


### PR DESCRIPTION
* Implemented a list of categories with clickable cards that redirect to the `subjects` page with list of all subjects related to that category.
* Added `View more` button to load more cards. It hides when no more cards are available.
* Added icons from `MUI` for each category.
* The` icon color `and `background color` are dynamically received from the backend.

<img width="1095" alt="Знімок екрана 2025-05-05 о 22 20 26" src="https://github.com/user-attachments/assets/96ae90bf-7f8a-4aba-852d-fe27f24ef29b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Category cards now display with icons and appearance-based colors for improved visual clarity.
  - Categories page supports paginated loading of category cards, with a "Load More" button for easier browsing.
  - Category icons are consistently mapped to each category for a unified look.

- **Style**
  - Updated card and image container styles for enhanced layout and appearance.
  - Category card titles now wrap text for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->