### PR TITLE
#279: Add a Category Not Found block

### DIFF
--- a/src/pages/categories/Categories.tsx
+++ b/src/pages/categories/Categories.tsx
@@ -9,6 +9,7 @@ import { styles } from '~/pages/categories/Categories.styles'
 import { authRoutes } from '~/router/constants/authRoutes'
 import useCategoriesNames from '~/hooks/use-categories-names'
 import { axiosClient } from '~/plugins/axiosClient'
+import { useModalContext } from '~/context/modal-context'
 
 import { CategoryNameInterface, SizeEnum, CategoryInterface } from '~/types'
 
@@ -21,6 +22,8 @@ import OfferRequestBlock from '~/containers/find-offer/offer-request-block/Offer
 import CardsList from '~/components/cards-list/CardsList'
 import { CardWithLinkProps } from '~/components/card-with-link/CardWithLink'
 import { CategoryIconsMap } from '~/components/category-card/Icons'
+import CreateSubjectModal from '~/containers/find-offer/create-new-subject/CreateNewSubject'
+import NotFoundResults from '~/components/not-found-results/NotFoundResults'
 
 import { getNameById, getIdByName } from '~/utils/helper-functions'
 
@@ -42,6 +45,10 @@ const Categories = () => {
   const [page, setPage] = useState(1)
   const [loading, setLoading] = useState(false)
   const [hasMore, setHasMore] = useState(true)
+
+  const { openModal } = useModalContext()
+  const handleOpenModal = () => openModal({ component: <CreateSubjectModal /> })
+  const [invalidSearch, setInvalidSearch] = useState(false)
 
   const fetchCategories = useCallback(
     async (pageToLoad = 1) => {
@@ -142,10 +149,16 @@ const Categories = () => {
     const itemId = getIdByName(categoriesNamesItems, value)
 
     if (value) {
-      const idToSet = itemId || ''
-      searchParams.set('id', idToSet)
+      if (itemId) {
+        setInvalidSearch(false)
+        searchParams.set('id', itemId)
+      } else {
+        setInvalidSearch(true)
+        searchParams.set('id', '')
+      }
       setSearchParams(searchParams)
     } else {
+      setInvalidSearch(false)
       searchParams.delete('id')
       setSearchParams(searchParams)
     }
@@ -189,13 +202,22 @@ const Categories = () => {
           }}
         />
       </AppToolbar>
-      <CardsList
-        btnText={t('categoriesPage.viewMore')}
-        cards={cards}
-        isExpandable={showLoadMoreButton}
-        loading={loading}
-        onClick={handleLoadMore}
-      />
+
+      {invalidSearch ? (
+        <NotFoundResults
+          buttonText={t('errorMessages.buttonRequest', { name: 'categories' })}
+          description={t('errorMessages.tryAgainText', { name: 'categories' })}
+          onClick={handleOpenModal}
+        />
+      ) : (
+        <CardsList
+          btnText={t('categoriesPage.viewMore')}
+          cards={cards}
+          isExpandable={showLoadMoreButton}
+          loading={loading}
+          onClick={handleLoadMore}
+        />
+      )}
     </PageWrapper>
   )
 }


### PR DESCRIPTION
A check was added to detect when a user enters an invalid category name. 
> If the name doesn't match any known category, `invalidSearch` is set to `true`, allowing the UI to display a `not found` message.

<img width="535" alt="Знімок екрана 2025-05-07 о 11 19 23" src="https://github.com/user-attachments/assets/f60e8120-9f28-45b8-8309-72ea989eb434" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved search on the Categories page to handle invalid or unmatched search terms.
  - Added a dedicated message and option to create a new subject when no matching category is found.
  - Introduced a modal for creating a new subject directly from the search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->