### PR TITLE
#281: Add fallback icon and update CategoryIconsMap

### DIFF
--- a/src/components/category-card/Icons.tsx
+++ b/src/components/category-card/Icons.tsx
@@ -10,6 +10,8 @@ import NightlightIcon from '@mui/icons-material/Nightlight'
 import FactCheckIcon from '@mui/icons-material/FactCheck'
 import BiotechIcon from '@mui/icons-material/Biotech'
 import ComputerIcon from '@mui/icons-material/Computer'
+import CampaignIcon from '@mui/icons-material/Campaign'
+import CodeIcon from '@mui/icons-material/Code'
 
 export const CategoryIconsMap: Record<string, React.ElementType> = {
   Mathematics: TagIcon,
@@ -17,11 +19,13 @@ export const CategoryIconsMap: Record<string, React.ElementType> = {
   Music: MusicNoteIcon,
   Languages: TranslateIcon,
   Design: DesignServicesIcon,
-  Finances: AttachMoneyIcon,
+  Finance: AttachMoneyIcon,
   Painting: ColorLensIcon,
   Chemistry: ScienceIcon,
   Astronomy: NightlightIcon,
   Audit: FactCheckIcon,
   Biology: BiotechIcon,
-  'Computer science': ComputerIcon
+  'Computer science': ComputerIcon,
+  Programming: CodeIcon,
+  Marketing: CampaignIcon
 }

--- a/src/pages/categories/Categories.tsx
+++ b/src/pages/categories/Categories.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'react-router-dom'
 
 import { Box } from '@mui/material'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
+import DefaultCategoryIcon from '@mui/icons-material/Category'
 
 import { styles } from '~/pages/categories/Categories.styles'
 import { authRoutes } from '~/router/constants/authRoutes'
@@ -75,7 +76,7 @@ const Categories = () => {
           (card: CategoryInterface): CardWithLinkProps => ({
             _id: card._id,
             name: card.name,
-            icon: CategoryIconsMap[card.name],
+            icon: CategoryIconsMap[card.name] || DefaultCategoryIcon,
             description: `${Number(card.totalOffers)} Offers`,
             link: `${apiPath}/categories/${card._id}/subjects/names`,
             appearance: card.appearance


### PR DESCRIPTION
- Add missing category icons from backend seed data (e.g., Marketing, Programming, Finance instead of Finances).
- Implement fallback icon for categories not found in CategoryIconsMap.


<img width="919" alt="Знімок екрана 2025-05-07 о 12 47 42" src="https://github.com/user-attachments/assets/ab3cb0c5-213c-4072-b9fc-f435b96dce1c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added icons for the "Programming" and "Marketing" categories.
  - Updated the "Finances" category to "Finance" for improved consistency.

- **Bug Fixes**
  - Introduced a fallback icon for categories without a specific icon, ensuring all category cards display an icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->