### PR TITLE
#283 Show password icon toggles visibility for both password fields 

### DIFF
--- a/src/containers/guest-home-page/registration-form/RegistrationForm.tsx
+++ b/src/containers/guest-home-page/registration-form/RegistrationForm.tsx
@@ -57,8 +57,10 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({
   data,
   errors
 }) => {
-  const { inputVisibility: passwordVisibility, showInputText: showPassword } =
-    useInputVisibility()
+  const passwordVisibility = useInputVisibility(Boolean(errors.password))
+  const confirmPasswordVisibility = useInputVisibility(
+    Boolean(errors.confirmPassword)
+  )
 
   const [iAgreeCheck, setIAgreeCheck] = useState(false)
   const { setUnsavedChanges } = useModalContext()
@@ -132,8 +134,8 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({
       error: errors.password ? t(errors.password) : '',
       handleChange: handleChange('password'),
       handleBlur: handleBlur('password'),
-      type: showPassword ? 'text' : 'password',
-      InputProps: passwordVisibility,
+      type: passwordVisibility.showInputText ? 'text' : 'password',
+      InputProps: passwordVisibility.inputVisibility,
       sx: { mb: '5px' }
     },
     {
@@ -143,8 +145,8 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({
       error: errors.confirmPassword ? t(errors.confirmPassword) : '',
       handleChange: handleChange('confirmPassword'),
       handleBlur: handleBlur('confirmPassword'),
-      type: showPassword ? 'text' : 'password',
-      InputProps: passwordVisibility
+      type: confirmPasswordVisibility.showInputText ? 'text' : 'password',
+      InputProps: confirmPasswordVisibility.inputVisibility
     }
   ]
 


### PR DESCRIPTION
Added independent password visibility toggle for password and confirmPassword fields in RegistrationForm using separate instances of useInputVisibility.

![image](https://github.com/user-attachments/assets/03166974-7645-4c18-b269-8f686fafac38)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Password and confirm password fields now have independent visibility toggles, allowing users to control each field separately.
- **Bug Fixes**
  - Improved error handling for password and confirm password fields, ensuring visibility toggles respond correctly to individual field errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->