### PR TITLE
#274 subject-page-interactive-input-component

### DIFF
--- a/src/components/async-autocomlete/AsyncAutocomplete.tsx
+++ b/src/components/async-autocomlete/AsyncAutocomplete.tsx
@@ -7,12 +7,17 @@ import useAxios, { UseAxiosProps } from '~/hooks/use-axios'
 import { defaultResponses } from '~/constants'
 import { ServiceFunction, Category } from '~/types'
 
+type BaseAutocompleteProps<
+  T,
+  F extends boolean | undefined
+> = AutocompleteProps<T, undefined, undefined, F>
+
 interface AsyncAutocompleteProps<T, F extends boolean | undefined>
   extends Omit<
-    AutocompleteProps<T, undefined, undefined, F>,
+    BaseAutocompleteProps<T, F>,
     'value' | 'options' | 'renderInput'
   > {
-  service: ServiceFunction<T[]>
+  service: ServiceFunction<{ data: T[] }>
   valueField?: keyof T
   labelField?: keyof T
   value: T[keyof T] | null | Category
@@ -28,12 +33,17 @@ const AsyncAutocomplete = <T, F extends boolean | undefined = undefined>({
   textFieldProps,
   valueField,
   labelField,
-  //value,
+  value,
   service,
   axiosProps,
   ...props
 }: AsyncAutocompleteProps<T, F>) => {
-  const { loading, response, fetchData } = useAxios<T[]>({
+  const { loading, response, fetchData } = useAxios<
+    { data: T[] },
+    undefined,
+    T[]
+  >({
+    transform: (res) => res.data,
     service,
     fetchOnMount: false,
     defaultResponse: defaultResponses.array,
@@ -45,13 +55,15 @@ const AsyncAutocomplete = <T, F extends boolean | undefined = undefined>({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [service])
 
-  // const valueOption = useMemo(
-  //   () =>
-  //     response.find(
-  //       (option) => (valueField ? option[valueField] : option) === value
-  //     ) || null,
-  //   [response, value, valueField]
-  // )
+  const valueOption = useMemo(
+    () =>
+      Array.isArray(response) && response.length > 0
+        ? response.find(
+            (option) => (valueField ? option[valueField] : option) === value
+          ) || null
+        : null,
+    [response, value, valueField]
+  )
 
   const getOptionLabel = useMemo(
     () => (option: T) => (labelField ? option[labelField] : option) || '',
@@ -76,9 +88,9 @@ const AsyncAutocomplete = <T, F extends boolean | undefined = undefined>({
       isOptionEqualToValue={isOptionEqualToValue}
       loading={loading}
       onFocus={handleFocus}
-      //options={response}
+      options={response}
       textFieldProps={textFieldProps}
-      //value={valueOption}
+      value={valueOption}
       {...props}
     />
   )

--- a/src/pages/subjects/Subjects.tsx
+++ b/src/pages/subjects/Subjects.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router-dom'
-
 import axios from 'axios'
 
 import Box from '@mui/material/Box'
@@ -26,7 +25,6 @@ import AsyncAutocomplete from '~/components/async-autocomlete/AsyncAutocomplete'
 import useBreakpoints from '~/hooks/use-breakpoints'
 import serviceIcon from '~/assets/img/student-home-page/service_icon.png'
 import { getOpositeRole } from '~/utils/helper-functions'
-import { mapArrayByField } from '~/utils/map-array-by-field'
 
 import {
   CategoryNameInterface,
@@ -57,10 +55,9 @@ const Subjects = () => {
 
   const oppositeRole = getOpositeRole(userRole) || 'tutor'
 
-  const transform = useCallback(
-    (data: SubjectNameInterface[]): string[] => mapArrayByField(data, 'name'),
-    []
-  )
+  const transform: (
+    data: SubjectNameInterface[] | { data: SubjectNameInterface[] }
+  ) => SubjectNameInterface[] = (res) => (Array.isArray(res) ? res : res.data)
 
   const {
     loading: subjectNamesLoading,
@@ -72,12 +69,26 @@ const Subjects = () => {
     transform
   })
 
-  const getSubjectNames = () => {
+  const getSubjectNames = useCallback(() => {
     if (!isFetched) {
       void fetchData()
       setIsFetched(true)
     }
-  }
+  }, [fetchData, isFetched])
+
+  const subjectOptions: string[] = useMemo(
+    () =>
+      categoryId && subjects.length > 0
+        ? subjectsNamesItems.map((item) => item.name)
+        : [],
+    [subjectsNamesItems, categoryId, subjects]
+  )
+
+  useEffect(() => {
+    if (categoryId) {
+      getSubjectNames()
+    }
+  }, [categoryId, getSubjectNames])
 
   const fetchSubjects = useCallback(async () => {
     if (!categoryId) {
@@ -93,7 +104,6 @@ const Subjects = () => {
           withCredentials: true
         }
       )
-      console.log('Server response:', response.data)
 
       if (!response.data || !Array.isArray(response.data.data)) {
         console.warn(
@@ -193,7 +203,7 @@ const Subjects = () => {
         />
         <DirectionLink
           after={<ArrowForwardIcon fontSize={SizeEnum.Small} />}
-          linkTo={authRoutes.categories.path}
+          linkTo={authRoutes.findOffers.path}
           title={t('subjectsPage.subjects.showAllOffers')}
         />
       </Box>
@@ -201,10 +211,8 @@ const Subjects = () => {
         {!breakpoints.isMobile && autoCompleteCategories}
         <SearchAutocomplete
           loading={subjectNamesLoading}
-          onFocus={getSubjectNames}
-          onSearchChange={() => setSubjects([])}
-          options={subjectsNamesItems}
-          search={match}
+          options={subjectOptions}
+          search={match || ''}
           setSearch={setMatch}
           textFieldProps={{
             label: t('subjectsPage.subjects.searchLabel')


### PR DESCRIPTION
**Input functionality implemented in Subjects page**

Category preload by ID from URL: If a category ID is present in the URL, the corresponding category is preselected in the input.

Subject list filtering: Once a category is selected, the input displays a list of related subjects available for selection.

Dynamic page title: The page title updates based on the selected category.

Navigation buttons work as expected:

"Categories" navigates to the full category list.

"Show offers" displays offers relevant to the selected subject/category.

This improves UX by streamlining the category/subject selection process and ensuring consistent navigation behavior.

![image](https://github.com/user-attachments/assets/55f48d0d-2815-4fd5-a974-a55cb8736266)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the handling and transformation of subject names in the Subjects page for more consistent data processing.
  - Updated the logic for fetching and displaying autocomplete options based on selected categories.
  - Enhanced the AsyncAutocomplete component for better type safety and response handling.
- **Style**
  - Removed unnecessary debug output from the Subjects page.
- **New Features**
  - Updated navigation link for "show all offers" to direct users to the find offers page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->