### PR TITLE
#110: Implement container for offer cards

### DIFF
--- a/src/containers/find-offer/offer-cards-list/OfferCardsList.styles.ts
+++ b/src/containers/find-offer/offer-cards-list/OfferCardsList.styles.ts
@@ -1,0 +1,7 @@
+export const styles = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2
+  }
+}

--- a/src/containers/find-offer/offer-cards-list/OfferCardsList.tsx
+++ b/src/containers/find-offer/offer-cards-list/OfferCardsList.tsx
@@ -1,0 +1,19 @@
+import OfferCard from '~/components/offer-card/OfferCard'
+import { styles } from '~/containers/find-offer/offer-cards-list/OfferCardsList.styles'
+import { Box } from '@mui/material'
+
+const OfferCardsList = () => {
+  const mockOffers = Array.from({ length: 5 })
+
+  return (
+    <Box sx={styles.container}>
+      {mockOffers.map((_, index) => (
+        <Box key={index}>
+          <OfferCard />
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
+export default OfferCardsList

--- a/src/pages/find-offers/FindOffers.tsx
+++ b/src/pages/find-offers/FindOffers.tsx
@@ -1,10 +1,12 @@
 import PageWrapper from '~/components/page-wrapper/PageWrapper'
 import OfferRequestBlock from '~/containers/find-offer/offer-request-block/OfferRequestBlock'
+import OfferCardsList from '~/containers/find-offer/offer-cards-list/OfferCardsList'
 
 const FindOffers = () => {
   return (
     <PageWrapper>
       <OfferRequestBlock />
+      <OfferCardsList />
     </PageWrapper>
   )
 }


### PR DESCRIPTION
Implemented a container for offer cards with mocked data for testing.
<img width="1381" alt="Знімок екрана 2025-05-08 о 13 28 12" src="https://github.com/user-attachments/assets/39e0bf6f-7af1-45b2-9956-3f16e3286cfa" />


> Currently, it displays all cards without view mode switching. This will be implemented in the next PR. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an offer cards list component that displays multiple offer cards on the Find Offers page.
- **Style**
  - Added new styling for the offer cards list layout to improve visual organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->