### PR TITLE
#293-bugfix-find-block-labels

### DIFF
--- a/src/components/title-block/TitleBlock.tsx
+++ b/src/components/title-block/TitleBlock.tsx
@@ -30,7 +30,7 @@ const TitleBlock: FC<TitleBlockProps> = ({
     <Box className='section' sx={{ ...styles.container, ...style }}>
       <Box sx={styles.info}>
         <TitleWithDescription
-          description={t(`${translationKey}.description.${userRole}`)}
+          description={t(`${translationKey}.description`)}
           style={styles.titleWithDescription}
           title={t(`${translationKey}.title.${userRole}`)}
         />

--- a/src/constants/translations/en/student-home-page.json
+++ b/src/constants/translations/en/student-home-page.json
@@ -4,8 +4,8 @@
       "student": "A Global Network of Tutors",
       "tutor": "A Global Network of Students"
     },
-    "description": "A Space2Study platform is a place where you can learn from the best. Type who or what would you like to learn from and find the best tutor.",
-    "label": "Who or what do you want to learn from?",
+    "description": "A Space2Study platform is a place where you can learn from the best. Type what would you like to learn and find the right tutors for that.",
+    "label": "What would you like to learn?",
     "button": "Find tutor"
   },
   "popularCategories": {
@@ -41,7 +41,7 @@
     "bookLesson": "How to book a lesson",
     "bookLessonDescription": "Respond to the tutor’s offer by creating a cooperation, where you confirm the required level of training and price, or set your own. It’s crucial to have a clear communication channel and discuss expectations, including pricing and scheduling.",
     "rules": "Rules for students",
-    "rulesDescription": "Students have the right to choose the offer they like and agree to its terms. Students also have the right to create their own requests for a course, to which the tutor will respond. Students cannot use learning materials for commercial purposes or distribution and should avoid posting obscene messages, photos, or comments.", 
+    "rulesDescription": "Students have the right to choose the offer they like and agree to its terms. Students also have the right to create their own requests for a course, to which the tutor will respond. Students cannot use learning materials for commercial purposes or distribution and should avoid posting obscene messages, photos, or comments.",
     "howPayLessons": "How you can pay for lessons",
     "howPayLessonsDescription": "Payment methods for tuition are negotiated between the tutor and the student during the cooperation setup. Space2Study platform’s primary role is to facilitate the search for the desired courses and does not impose any commissions on approved collaborations."
   }

--- a/src/constants/translations/en/tutor-home-page.json
+++ b/src/constants/translations/en/tutor-home-page.json
@@ -3,8 +3,8 @@
     "title": {
       "tutor": "A Global Network of Students"
     },
-    "description": "A Space2Study platform is the best place where you can teach. Type who or what would you like to teach and find students for that.",
-    "label": "Who or what do you want to teach?",
+    "description": "A Space2Study platform is a place where you can learn from the best. Type what would you like to teach and find students for that.",
+    "label": "What would you like to teach?",
     "button": "Find student"
   },
   "popularCategories": {


### PR DESCRIPTION
**Find Block description and input label fixed both in studen and tutor home pages.**

Before:
![image](https://github.com/user-attachments/assets/424e48d5-199b-48f8-8e2b-16016ef5cfca)


After:
![image](https://github.com/user-attachments/assets/f5eb08d5-c558-45aa-8751-437680460858)

![image](https://github.com/user-attachments/assets/2ac7221c-0545-4423-9fed-61a1d2ea2fc1)
---





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated various English translation texts for student and tutor home pages to use clearer, simplified language and improved tone.
- **Bug Fixes**
	- Adjusted description text sourcing to be consistent across user roles, ensuring all users see the same description regardless of role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->