### PR TITLE
#109: Add view switcher to find offers page

### DIFF
--- a/src/components/view-switcher/ViewSwitcher.styles.ts
+++ b/src/components/view-switcher/ViewSwitcher.styles.ts
@@ -1,0 +1,23 @@
+export const styles = {
+  switcher: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    mb: '24px',
+    mt: '48px',
+    gap: '8px'
+  },
+  icon: {
+    width: '48px',
+    height: '48px',
+    padding: '16px 12px',
+    color: '#263238',
+    border: '1px solid #B0BEC5',
+    borderRadius: '4px',
+    '&:hover': {
+      backgroundColor: 'transparent'
+    }
+  },
+  activeIcon: {
+    borderColor: '#263238'
+  }
+}

--- a/src/components/view-switcher/ViewSwitcher.tsx
+++ b/src/components/view-switcher/ViewSwitcher.tsx
@@ -1,0 +1,38 @@
+import { IconButton, Box } from '@mui/material'
+import GridViewIcon from '@mui/icons-material/GridView'
+import ListIcon from '@mui/icons-material/List'
+import { styles } from '~/components/view-switcher/ViewSwitcher.styles'
+
+interface ViewSwitcherProps {
+  isGridView: boolean
+  setIsGridView: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+const ViewSwitcher = ({ isGridView, setIsGridView }: ViewSwitcherProps) => {
+  return (
+    <Box sx={styles.switcher}>
+      <IconButton
+        aria-label='List view'
+        onClick={() => setIsGridView(false)}
+        sx={{
+          ...styles.icon,
+          ...(isGridView ? {} : styles.activeIcon)
+        }}
+      >
+        <ListIcon />
+      </IconButton>
+      <IconButton
+        aria-label='Grid view'
+        onClick={() => setIsGridView(true)}
+        sx={{
+          ...styles.icon,
+          ...(isGridView ? styles.activeIcon : {})
+        }}
+      >
+        <GridViewIcon />
+      </IconButton>
+    </Box>
+  )
+}
+
+export default ViewSwitcher

--- a/src/containers/find-offer/offer-cards-list/OfferCardsList.styles.ts
+++ b/src/containers/find-offer/offer-cards-list/OfferCardsList.styles.ts
@@ -3,5 +3,13 @@ export const styles = {
     display: 'flex',
     flexDirection: 'column',
     gap: 2
+  },
+  gridView: {
+    borderRadius: 2,
+    textAlign: 'center'
+  },
+  inlineView: {
+    p: 2,
+    borderRadius: 2
   }
 }

--- a/src/containers/find-offer/offer-cards-list/OfferCardsList.tsx
+++ b/src/containers/find-offer/offer-cards-list/OfferCardsList.tsx
@@ -1,17 +1,35 @@
+import { Grid, Box, Stack } from '@mui/material'
 import OfferCard from '~/components/offer-card/OfferCard'
 import { styles } from '~/containers/find-offer/offer-cards-list/OfferCardsList.styles'
-import { Box } from '@mui/material'
 
-const OfferCardsList = () => {
+interface ViewSwitcherProps {
+  isGridView: boolean
+}
+
+const OfferCardsList = ({ isGridView }: ViewSwitcherProps) => {
   const mockOffers = Array.from({ length: 5 })
 
   return (
-    <Box sx={styles.container}>
-      {mockOffers.map((_, index) => (
-        <Box key={index}>
-          <OfferCard />
-        </Box>
-      ))}
+    <Box>
+      {isGridView ? (
+        <Grid container spacing={2}>
+          {mockOffers.map((_, index) => (
+            <Grid item key={index} md={4} sm={6} xs={12}>
+              <Box sx={{ ...styles.container, ...styles.gridView }}>
+                <OfferCard />
+              </Box>
+            </Grid>
+          ))}
+        </Grid>
+      ) : (
+        <Stack spacing={2}>
+          {mockOffers.map((_, index) => (
+            <Box key={index} sx={{ ...styles.container, ...styles.inlineView }}>
+              <OfferCard />
+            </Box>
+          ))}
+        </Stack>
+      )}
     </Box>
   )
 }

--- a/src/pages/categories/Categories.tsx
+++ b/src/pages/categories/Categories.tsx
@@ -28,8 +28,6 @@ import NotFoundResults from '~/components/not-found-results/NotFoundResults'
 
 import { getNameById, getIdByName } from '~/utils/helper-functions'
 
-import ComputerIcon from '@mui/icons-material/Computer'
-
 const getAccessTokenFromCookie = () => {
   const match = document.cookie.match(/(?:^|; )access_token=([^;]*)/)
   return match ? match[1] : ''

--- a/src/pages/find-offers/FindOffers.tsx
+++ b/src/pages/find-offers/FindOffers.tsx
@@ -1,12 +1,17 @@
+import { useState } from 'react'
 import PageWrapper from '~/components/page-wrapper/PageWrapper'
 import OfferRequestBlock from '~/containers/find-offer/offer-request-block/OfferRequestBlock'
 import OfferCardsList from '~/containers/find-offer/offer-cards-list/OfferCardsList'
+import ViewSwitcher from '~/components/view-switcher/ViewSwitcher'
 
 const FindOffers = () => {
+  const [isGridView, setIsGridView] = useState(true)
+
   return (
     <PageWrapper>
       <OfferRequestBlock />
-      <OfferCardsList />
+      <ViewSwitcher isGridView={isGridView} setIsGridView={setIsGridView} />
+      <OfferCardsList isGridView={isGridView} />
     </PageWrapper>
   )
 }


### PR DESCRIPTION
- Added a view switcher to the "Find Offers" page to toggle between grid and inline views.
- Removed unused import ComputerIcon ('ComputerIcon' is defined but never used).

<img width="1408" alt="Знімок екрана 2025-05-09 о 09 47 14" src="https://github.com/user-attachments/assets/ca7ba4cf-8657-4c4a-b62a-856bd56f8edb" />
<img width="1307" alt="Знімок екрана 2025-05-09 о 09 47 28" src="https://github.com/user-attachments/assets/8fffa71e-43f4-4909-9fc3-8a0f37c05462" />

> For testing the grid layout, temporarily removed `md={4} `from
> `<Grid item key={index} md={4} sm={6} xs={12}>`
> because the square card layout isn't implemented yet ([[Find offers] Implement offer card (square version)](https://github.com/orgs/Space2Study-UA-1355-01/projects/1/views/1?pane=issue&itemId=105212975&issue=Space2Study-UA-1355-01%7CIssues%7C115)). The current card doesn't fit well in this config, so I used `sm={6} xs={12}`. Once the square version is ready, all breakpoints will be properly supported.
> 
> 
