### PR TITLE
#297-bugfix-default-route-rendering-when-userRole-selected/not-selected

### DIFF
--- a/src/router/helpers/HomeRoute.tsx
+++ b/src/router/helpers/HomeRoute.tsx
@@ -1,18 +1,14 @@
-import { useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Navigate } from 'react-router-dom'
 import { useAppSelector } from '~/hooks/use-redux'
 import GuestHomePage from '~/pages/guest-home-page/GuestHome'
 import { guestRoutes } from '~/router/constants/guestRoutes'
 
 const HomeRoute = () => {
-  const navigate = useNavigate()
   const { userRole } = useAppSelector((state) => state.appMain)
 
-  useEffect(() => {
-    if (userRole) {
-      navigate(guestRoutes[userRole].route)
-    }
-  }, [navigate, userRole])
+  if (userRole) {
+    return <Navigate replace to={guestRoutes[userRole]?.route} />
+  }
 
   return <GuestHomePage />
 }

--- a/src/tests/unit/router/helpers/HomeRoute.spec.jsx
+++ b/src/tests/unit/router/helpers/HomeRoute.spec.jsx
@@ -2,11 +2,13 @@ import { renderWithProviders } from '~tests/test-utils'
 import { screen } from '@testing-library/react'
 import HomeRoute from '~/router/helpers/HomeRoute'
 
-const mockedUseNavigate = vi.fn()
-vi.mock('react-router-dom', async () => ({
-  ...(await vi.importActual('react-router-dom')),
-  useNavigate: () => mockedUseNavigate
-}))
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    Navigate: ({ to }) => <div>Redirected to {to}</div>
+  }
+})
 
 const userId = '63f5d0ebb'
 const studentState = {
@@ -29,27 +31,27 @@ describe('HomeRoute component', () => {
     expect(welcomeDescription).toBeInTheDocument()
   })
 
-  it('should navigate to "student" when userRole is corresponding', () => {
+  it('should redirect to "student" when userRole is student', () => {
     renderWithProviders(<HomeRoute />, {
       preloadedState: studentState
     })
 
-    expect(mockedUseNavigate).toHaveBeenCalledWith('student')
+    expect(screen.getByText('Redirected to student')).toBeInTheDocument()
   })
 
-  it('should navigate to "tutor" when userRole is corresponded', () => {
+  it('should redirect to "tutor" when userRole is tutor', () => {
     renderWithProviders(<HomeRoute />, {
       preloadedState: tutorState
     })
 
-    expect(mockedUseNavigate).toHaveBeenCalledWith('tutor')
+    expect(screen.getByText('Redirected to tutor')).toBeInTheDocument()
   })
 
-  it('should navigate to "admin" when userRole is corresponded', () => {
+  it('should redirect to "admin" when userRole is admin', () => {
     renderWithProviders(<HomeRoute />, {
       preloadedState: adminState
     })
 
-    expect(mockedUseNavigate).toHaveBeenCalledWith('admin')
+    expect(screen.getByText('Redirected to admin')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
**Description** 
This PR fixes a bug where visiting the root route (/) with an authenticated user resulted in a 404 Not Found page instead of 
redirecting to the appropriate role-based home page (/student, /tutor).


**🔧 Changes:**
Replaced useEffect navigation logic with synchronous <Navigate /> logic based on userRole.
Ensured that if userRole is not present, the GuestHomePage is rendered instead.
Updated unit tests to mock <Navigate /> and verify proper redirection behavior for each user role.

![image](https://github.com/user-attachments/assets/9c91f14a-c3cc-439b-9135-a994253264bc)


![image](https://github.com/user-attachments/assets/9e53a2ab-dc27-4b58-8756-afee6a0a5a4b)


![image](https://github.com/user-attachments/assets/5b03bf2b-44fc-4e77-a7ac-7a049b0251bd)






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the HomeRoute component by simplifying the redirect logic for different user roles.
- **Tests**
  - Updated unit tests to check for redirect behavior using the new implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->