### PR TITLE
Add support for square and rectangle card variants

### DIFF
--- a/src/components/offer-card/OfferCard.tsx
+++ b/src/components/offer-card/OfferCard.tsx
@@ -37,7 +37,7 @@ const OfferCard: FC<OfferCardProps & { isGridView: boolean }> = ({
   isGridView,
   ...props
 }) => {
-  const isLargeScreen = useMediaQuery('(min-width: 620px)')
+  const isLargeScreen = useMediaQuery('(min-width: 660px)')
   if (isGridView || !isLargeScreen) {
     return <OfferCardSquare {...props} />
   } else {

--- a/src/components/offer-card/OfferCard.tsx
+++ b/src/components/offer-card/OfferCard.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react'
+import { useMediaQuery } from '@mui/material'
 
 import OfferCardRectangle from './offer-card-rectangle/OfferCardRectangle'
 import OfferCardSquare from './offer-card-square/OfferCardSquare'
@@ -8,7 +9,7 @@ interface RatingInfo {
   tutor: number
 }
 
-type AuthorRole = keyof RatingInfo
+export type AuthorRole = keyof RatingInfo
 
 export interface OfferCardProps {
   price: number
@@ -32,14 +33,16 @@ export interface OfferCardProps {
   onSendMessage?: () => void
 }
 
-const isGridView = true
-
-const OfferCard: FC<OfferCardProps> = (props) => {
-  return isGridView ? (
-    <OfferCardSquare {...props} />
-  ) : (
-    <OfferCardRectangle {...props} />
-  )
+const OfferCard: FC<OfferCardProps & { isGridView: boolean }> = ({
+  isGridView,
+  ...props
+}) => {
+  const isLargeScreen = useMediaQuery('(min-width: 620px)')
+  if (isGridView || !isLargeScreen) {
+    return <OfferCardSquare {...props} />
+  } else {
+    return <OfferCardRectangle {...props} />
+  }
 }
 
 export default OfferCard

--- a/src/containers/find-offer/offer-cards-list/OfferCardsList.styles.ts
+++ b/src/containers/find-offer/offer-cards-list/OfferCardsList.styles.ts
@@ -1,15 +1,9 @@
 export const styles = {
   container: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 2
-  },
-  gridView: {
+    gap: 2,
     borderRadius: 2,
-    textAlign: 'center'
-  },
-  inlineView: {
-    p: 2,
-    borderRadius: 2
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center'
   }
 }

--- a/src/containers/find-offer/offer-cards-list/OfferCardsList.tsx
+++ b/src/containers/find-offer/offer-cards-list/OfferCardsList.tsx
@@ -1,6 +1,7 @@
 import { Grid, Box, Stack } from '@mui/material'
 import OfferCard from '~/components/offer-card/OfferCard'
 import { styles } from '~/containers/find-offer/offer-cards-list/OfferCardsList.styles'
+import { AuthorRole } from '~/components/offer-card/OfferCard'
 
 interface ViewSwitcherProps {
   isGridView: boolean
@@ -9,14 +10,33 @@ interface ViewSwitcherProps {
 const OfferCardsList = ({ isGridView }: ViewSwitcherProps) => {
   const mockOffers = Array.from({ length: 5 })
 
+  const offerData = {
+    price: 100,
+    proficiencyLevel: 'Beginner',
+    title: 'Offer Title',
+    description: 'This is a description of the offer.',
+    languages: ['English', 'Spanish'],
+    authorRole: 'student' as AuthorRole,
+    author: {
+      firstName: 'John',
+      lastName: 'Doe',
+      photo: '',
+      totalReviews: { student: 10, tutor: 5 },
+      averageRating: { student: 4.5, tutor: 4.2 }
+    },
+    subject: { name: 'Mathematics' },
+    onShowDetails: () => console.log('View details clicked'),
+    onSendMessage: () => console.log('Send message clicked')
+  }
+
   return (
     <Box>
       {isGridView ? (
         <Grid container spacing={2}>
           {mockOffers.map((_, index) => (
             <Grid item key={index} md={4} sm={6} xs={12}>
-              <Box sx={{ ...styles.container, ...styles.gridView }}>
-                <OfferCard />
+              <Box sx={styles.container}>
+                <OfferCard {...offerData} isGridView={isGridView} />
               </Box>
             </Grid>
           ))}
@@ -24,8 +44,8 @@ const OfferCardsList = ({ isGridView }: ViewSwitcherProps) => {
       ) : (
         <Stack spacing={2}>
           {mockOffers.map((_, index) => (
-            <Box key={index} sx={{ ...styles.container, ...styles.inlineView }}>
-              <OfferCard />
+            <Box key={index} sx={styles.container}>
+              <OfferCard {...offerData} isGridView={isGridView} />
             </Box>
           ))}
         </Stack>


### PR DESCRIPTION
Implement support for rendering square and rectangle card variants. Tested with mocked data.
<img width="1081" alt="Знімок екрана 2025-05-13 о 10 05 58" src="https://github.com/user-attachments/assets/42d75cfb-2a3d-4751-9931-d0ba57e73e60" />
<img width="971" alt="Знімок екрана 2025-05-13 о 10 06 08" src="https://github.com/user-attachments/assets/54f25de5-efbe-4118-b81f-3d198684ecf2" />


Applied a `media query` fallback to switch to the square layout on small screens `(<660px)`, avoiding clipping issues with the rectangle card.
**`Before:`**
<img width="517" alt="Знімок екрана 2025-05-13 о 09 53 12" src="https://github.com/user-attachments/assets/637d5f40-e385-4b9a-a184-82183b18ccec" />
**`After:`**
<img width="362" alt="Знімок екрана 2025-05-13 о 10 29 47" src="https://github.com/user-attachments/assets/792c2f9e-0ca6-4dd1-899d-33a953c0c9f4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Offer cards now adapt their layout based on screen size and a grid view setting, providing a more responsive and flexible user experience.

- **Style**
  - Updated offer card list layout to use centered alignment, improving visual consistency and spacing.

- **Refactor**
  - Offer cards now display detailed mock data for a more informative preview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->