### PR TITLE
#302-bugfix-labels-home-page-spacing

### DIFF
--- a/src/components/title-block/TitleBlock.tsx
+++ b/src/components/title-block/TitleBlock.tsx
@@ -30,7 +30,7 @@ const TitleBlock: FC<TitleBlockProps> = ({
     <Box className='section' sx={{ ...styles.container, ...style }}>
       <Box sx={styles.info}>
         <TitleWithDescription
-          description={t(`${translationKey}.description`)}
+          description={t(`${translationKey}.description.${userRole}`)}
           style={styles.titleWithDescription}
           title={t(`${translationKey}.title.${userRole}`)}
         />

--- a/src/constants/translations/en/student-home-page.json
+++ b/src/constants/translations/en/student-home-page.json
@@ -4,7 +4,9 @@
       "student": "A Global Network of Tutors",
       "tutor": "A Global Network of Students"
     },
-    "description": "A Space2Study platform is a place where you can learn from the best. Type what would you like to learn and find the right tutors for that.",
+    "description": {
+      "student": "Space2Study is a platform where you can learn from the best. Type what you'd like to learn and find the right tutors for it."
+    },
     "label": "What would you like to learn?",
     "button": "Find tutor"
   },

--- a/src/constants/translations/en/tutor-home-page.json
+++ b/src/constants/translations/en/tutor-home-page.json
@@ -3,7 +3,9 @@
     "title": {
       "tutor": "A Global Network of Students"
     },
-    "description": "A Space2Study platform is a place where you can learn from the best. Type what would you like to teach and find students for that.",
+    "description": {
+      "tutor": "A Space2Study platform is a place where you can learn from the best. Type what would you like to teach and find students for that."
+    },
     "label": "What would you like to teach?",
     "button": "Find student"
   },

--- a/src/pages/student-home/StudentHome.tsx
+++ b/src/pages/student-home/StudentHome.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import Container from '@mui/material/Container'
+import { Stack } from '@mui/material'
 
 import { useAppSelector } from '~/hooks/use-redux'
 import { useModalContext } from '~/context/modal-context'
@@ -31,11 +32,13 @@ const StudentHome = () => {
   }, [openModal, isFirstLogin, userRole])
 
   return (
-    <Container data-testid='studentHome' sx={{ flex: 1 }}>
-      <FindBlock translationKey={translationKey} />
-      {/* Popular Categories */}
-      <HowItWorksBlock />
-      <Faq />
+    <Container data-testid='studentHome' sx={{ flex: 1, pt: '80px' }}>
+      <Stack spacing='80px'>
+        <FindBlock translationKey={translationKey} />
+        {/* Popular Categories */}
+        <HowItWorksBlock />
+        <Faq />
+      </Stack>
     </Container>
   )
 }

--- a/src/pages/tutor-home/TutorHome.tsx
+++ b/src/pages/tutor-home/TutorHome.tsx
@@ -9,7 +9,7 @@ import FindBlock from '~/components/find-block/FindBlock'
 import { styles } from '~/pages/tutor-home/TutorHome.styles'
 import { translationKey } from '~/components/find-block/find-student-constants'
 import { HowItWorksBlock } from '~/components/how-it-works/HowItWorksBlock'
-import { Container } from '@mui/material'
+import { Container, Stack } from '@mui/material'
 
 import Faq from '~/containers/student-home-page/faq/Faq'
 
@@ -29,10 +29,12 @@ const TutorHome = () => {
   }, [openModal, isFirstLogin, userRole])
 
   return (
-    <Container data-testid='tutorHome' sx={{ flex: 1 }}>
-      <FindBlock translationKey={translationKey} />
-      <HowItWorksBlock />
-      <Faq />
+    <Container data-testid='tutorHome' sx={{ flex: 1, pt: '80px' }}>
+      <Stack spacing='80px'>
+        <FindBlock translationKey={translationKey} />
+        <HowItWorksBlock />
+        <Faq />
+      </Stack>
     </Container>
   )
 }


### PR DESCRIPTION
**Description**
In this PR I fixed labling issue on FindOffers Page both for students and tutors

Before fix:
![image](https://github.com/user-attachments/assets/d50d1531-111f-4c3b-94b4-10942d4f4ee8)

After fix:
![image](https://github.com/user-attachments/assets/69cbad42-dbf9-4954-924a-e2ba195934b9)


---

Updated spacing on Tutor/Student Home pages to improive UI 

Before fix:
![image](https://github.com/user-attachments/assets/ba004334-c641-44c2-9c64-9a6ec564c95b)

After fix:
![image](https://github.com/user-attachments/assets/90c958a1-8536-488d-8acf-d38c9beb7aa2)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated page layouts for student and tutor home pages with improved spacing and padding for a cleaner appearance.

- **Bug Fixes**
  - Adjusted translation keys so that descriptions are now tailored to user roles, ensuring accurate and role-specific text display.

- **Chores**
  - Updated translation files to use role-specific description formats for both student and tutor home pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->