### PR TITLE
#296: Add pagination to Offers page

### DIFF
--- a/src/containers/find-offer/offer-cards-list/OfferCardsList.tsx
+++ b/src/containers/find-offer/offer-cards-list/OfferCardsList.tsx
@@ -1,4 +1,7 @@
-import { Grid, Box, Stack } from '@mui/material'
+import { Grid, Box, Stack, Pagination } from '@mui/material'
+
+import usePagination from '~/hooks/table/use-pagination'
+
 import OfferCard from '~/components/offer-card/OfferCard'
 import { styles } from '~/containers/find-offer/offer-cards-list/OfferCardsList.styles'
 import { AuthorRole } from '~/components/offer-card/OfferCard'
@@ -8,7 +11,15 @@ interface ViewSwitcherProps {
 }
 
 const OfferCardsList = ({ isGridView }: ViewSwitcherProps) => {
-  const mockOffers = Array.from({ length: 5 })
+  const mockOffers = Array.from({ length: 7 })
+  const { page, rowsPerPage, pageCount, handleChangePage } = usePagination({
+    itemsCount: mockOffers.length,
+    itemsPerPage: 6,
+    defaultPage: 1
+  })
+
+  const startIndex = (page - 1) * rowsPerPage
+  const paginatedOffers = mockOffers.slice(startIndex, startIndex + rowsPerPage)
 
   const offerData = {
     price: 100,
@@ -33,7 +44,7 @@ const OfferCardsList = ({ isGridView }: ViewSwitcherProps) => {
     <Box>
       {isGridView ? (
         <Grid container spacing={2}>
-          {mockOffers.map((_, index) => (
+          {paginatedOffers.map((_, index) => (
             <Grid item key={index} md={4} sm={6} xs={12}>
               <Box sx={styles.container}>
                 <OfferCard {...offerData} isGridView={isGridView} />
@@ -43,13 +54,21 @@ const OfferCardsList = ({ isGridView }: ViewSwitcherProps) => {
         </Grid>
       ) : (
         <Stack spacing={2}>
-          {mockOffers.map((_, index) => (
+          {paginatedOffers.map((_, index) => (
             <Box key={index} sx={styles.container}>
               <OfferCard {...offerData} isGridView={isGridView} />
             </Box>
           ))}
         </Stack>
       )}
+      <Box display='flex' justifyContent='center' mt={4}>
+        <Pagination
+          color='primary'
+          count={pageCount}
+          onChange={handleChangePage}
+          page={page}
+        />
+      </Box>
     </Box>
   )
 }


### PR DESCRIPTION
Added pagination to the Offers page using MUI's Pagination component and a custom `usePagination` hook to manage page state and navigation.
<img width="762" alt="Знімок екрана 2025-05-14 о 10 21 55" src="https://github.com/user-attachments/assets/bcebb889-62ec-45c0-aaec-cab214a75976" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced pagination to the offer cards list, allowing users to navigate between pages of offers.
	- Pagination controls are now available below the offer cards and are visually centered for improved usability.
- **Enhancements**
	- Increased the number of displayed offers, providing more options for users to browse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->