### PR TITLE
feature-implement-request-new-study-modal

### DIFF
--- a/src/constants/request.ts
+++ b/src/constants/request.ts
@@ -25,7 +25,8 @@ export const URLs = {
   },
   subjects: {
     get: '/subjects',
-    getNames: '/subjects/names'
+    getNames: '/subjects/names',
+    post: '/subjects'
   },
   resources: {
     questions: {

--- a/src/constants/translations/en/categories-page.json
+++ b/src/constants/translations/en/categories-page.json
@@ -11,7 +11,7 @@
     "description": "If you can’t find a specific category or subject that you need, you can submit a request to our team to review your request and take necessary actions.",
     "subject": "Create a new subject",
     "category": "Add subject to existing category or create a new one.",
-    "info": "Provide a brief explanation of why you believe this subject or category should be added.",
+    "info": "Provide a brief explanation of why you believe this subject should be added.",
     "labels": { "subject": "New subject" }
   }
 }

--- a/src/containers/find-offer/create-new-subject/CreateNewSubject.constants.ts
+++ b/src/containers/find-offer/create-new-subject/CreateNewSubject.constants.ts
@@ -5,7 +5,7 @@ export const validations = {
     emptyField(value, 'offerPage.errorMessages.category'),
   subject: (value: string) =>
     emptyField(value, 'offerPage.errorMessages.subject'),
-  info: (value: string) =>
+  description: (value: string) =>
     emptyField(
       value,
       'offerPage.errorMessages.description',

--- a/src/containers/find-offer/create-new-subject/CreateNewSubject.constants.ts
+++ b/src/containers/find-offer/create-new-subject/CreateNewSubject.constants.ts
@@ -3,8 +3,7 @@ import { emptyField, textField } from '~/utils/validations/common'
 export const validations = {
   category: (value: string | null) =>
     emptyField(value, 'offerPage.errorMessages.category'),
-  subject: (value: string) =>
-    emptyField(value, 'offerPage.errorMessages.subject'),
+  name: (value: string) => emptyField(value, 'offerPage.errorMessages.subject'),
   description: (value: string) =>
     emptyField(
       value,

--- a/src/containers/find-offer/create-new-subject/CreateNewSubject.tsx
+++ b/src/containers/find-offer/create-new-subject/CreateNewSubject.tsx
@@ -27,6 +27,7 @@ import { snackbarVariants } from '~/constants'
 import { categoryService } from '~/services/category-service'
 import { validations } from '~/containers/find-offer/create-new-subject/CreateNewSubject.constants'
 import { styles } from '~/containers/find-offer/create-new-subject/CreateNewSubject.styles'
+import { subjectService } from '~/services/subject-service'
 
 const CreateSubjectModal = () => {
   const { closeModal } = useModalContext()
@@ -49,7 +50,8 @@ const CreateSubjectModal = () => {
     closeModal()
   }
 
-  const sendSubjectRequest = (): Promise<AxiosResponse> => null
+  const sendSubjectRequest = (): Promise<AxiosResponse> =>
+    subjectService.postSubject(data)
 
   const { loading, fetchData } = useAxios({
     service: sendSubjectRequest,
@@ -71,7 +73,7 @@ const CreateSubjectModal = () => {
     initialValues: {
       subject: '',
       category: '',
-      info: ''
+      description: ''
     },
     onSubmit: fetchData,
     validations
@@ -86,11 +88,15 @@ const CreateSubjectModal = () => {
     value: CategoryNameInterface | null | string
   ) => {
     if (typeof value === 'object') {
-      handleNonInputValueChange('category', value?.name ?? '')
+      handleNonInputValueChange('category', value?._id ?? '')
+      console.log('first if ')
     } else {
-      handleNonInputValueChange('category', value)
+      console.log('second if ')
+      handleNonInputValueChange('category', '')
     }
   }
+
+  console.log(errors)
 
   return (
     <Box sx={styles.root}>
@@ -110,6 +116,7 @@ const CreateSubjectModal = () => {
         <Typography sx={styles.inputTitle}>
           {t('categoriesPage.newSubject.subject')}
         </Typography>
+        {/* subject input */}
         <AppTextField
           errorMsg={t(errors.subject)}
           fullWidth
@@ -121,9 +128,9 @@ const CreateSubjectModal = () => {
         <Typography sx={styles.inputTitle}>
           {t('categoriesPage.newSubject.category')}
         </Typography>
+        {/* categories input  */}
         <AsyncAutocomplete
           fetchOnFocus
-          freeSolo
           labelField='name'
           onBlur={handleBlur('category')}
           onChange={handleCategoryChange}
@@ -135,18 +142,19 @@ const CreateSubjectModal = () => {
             helperText: t(errors.category) || ' '
           }}
           value={data.category}
-          valueField='name'
+          valueField='_id'
         />
+        {/* additional info input */}
         <AppTextArea
-          errorMsg={t(errors.info)}
+          errorMsg={t(errors.description)}
           fullWidth
           label={t('offerDetailsPage.enrollOffer.labels.info')}
           maxLength={1000}
-          onBlur={handleBlur('info')}
-          onChange={handleInputChange('info')}
+          onBlur={handleBlur('description')}
+          onChange={handleInputChange('description')}
           sx={styles.textArea}
           title={t('categoriesPage.newSubject.info')}
-          value={data.info}
+          value={data.description}
         />
         <AppButton
           loading={loading}

--- a/src/containers/find-offer/create-new-subject/CreateNewSubject.tsx
+++ b/src/containers/find-offer/create-new-subject/CreateNewSubject.tsx
@@ -7,7 +7,6 @@ import Typography from '@mui/material/Typography'
 
 import useAxios from '~/hooks/use-axios'
 import useForm from '~/hooks/use-form'
-import useConfirm from '~/hooks/use-confirm'
 import { useModalContext } from '~/context/modal-context'
 import { useSnackBarContext } from '~/context/snackbar-context'
 import Image from '~/assets/img/signup-dialog/student.svg'
@@ -30,8 +29,7 @@ import { styles } from '~/containers/find-offer/create-new-subject/CreateNewSubj
 import { subjectService } from '~/services/subject-service'
 
 const CreateSubjectModal = () => {
-  const { closeModal } = useModalContext()
-  const { setNeedConfirmation } = useConfirm()
+  const { closeModal, setUnsavedChanges } = useModalContext()
   const { setAlert } = useSnackBarContext()
   const { t } = useTranslation()
 
@@ -80,8 +78,8 @@ const CreateSubjectModal = () => {
   })
 
   useEffect(() => {
-    setNeedConfirmation(isDirty)
-  }, [isDirty, setNeedConfirmation])
+    setUnsavedChanges(isDirty)
+  }, [isDirty, setUnsavedChanges])
 
   const handleCategoryChange = (
     _: React.SyntheticEvent,
@@ -89,14 +87,10 @@ const CreateSubjectModal = () => {
   ) => {
     if (typeof value === 'object') {
       handleNonInputValueChange('category', value?._id ?? '')
-      console.log('first if ')
     } else {
-      console.log('second if ')
       handleNonInputValueChange('category', '')
     }
   }
-
-  console.log(errors)
 
   return (
     <Box sx={styles.root}>

--- a/src/containers/find-offer/create-new-subject/CreateNewSubject.tsx
+++ b/src/containers/find-offer/create-new-subject/CreateNewSubject.tsx
@@ -36,7 +36,7 @@ const CreateSubjectModal = () => {
   const handleResponseError = (error: ErrorResponse) => {
     setAlert({
       severity: snackbarVariants.error,
-      message: error ? `errors.${error.code}` : ''
+      message: error ? error.message : ''
     })
   }
 
@@ -69,7 +69,7 @@ const CreateSubjectModal = () => {
     handleSubmit
   } = useForm({
     initialValues: {
-      subject: '',
+      name: '',
       category: '',
       description: ''
     },
@@ -110,19 +110,17 @@ const CreateSubjectModal = () => {
         <Typography sx={styles.inputTitle}>
           {t('categoriesPage.newSubject.subject')}
         </Typography>
-        {/* subject input */}
         <AppTextField
-          errorMsg={t(errors.subject)}
+          errorMsg={t(errors.name)}
           fullWidth
           label={t('categoriesPage.newSubject.labels.subject')}
-          onBlur={handleBlur('subject')}
-          onChange={handleInputChange('subject')}
-          value={data.subject}
+          onBlur={handleBlur('name')}
+          onChange={handleInputChange('name')}
+          value={data.name}
         />
         <Typography sx={styles.inputTitle}>
           {t('categoriesPage.newSubject.category')}
         </Typography>
-        {/* categories input  */}
         <AsyncAutocomplete
           fetchOnFocus
           labelField='name'
@@ -138,7 +136,6 @@ const CreateSubjectModal = () => {
           value={data.category}
           valueField='_id'
         />
-        {/* additional info input */}
         <AppTextArea
           errorMsg={t(errors.description)}
           fullWidth

--- a/src/pages/find-offers/FindOffers.tsx
+++ b/src/pages/find-offers/FindOffers.tsx
@@ -37,7 +37,7 @@ const FindOffers = () => {
     if (categoryId && categoryId !== '') {
       return () => subjectService.getSubjects(undefined, categoryId)
     }
-    return subjectService.getAllSubjects
+    return () => subjectService.getAllSubjects({ limit: 99 })
   }, [categoryId])
 
   const onCategoryChange = (

--- a/src/services/subject-service.ts
+++ b/src/services/subject-service.ts
@@ -25,7 +25,7 @@ export const subjectService = {
     return axiosClient.get(`${category}${URLs.subjects.getNames}`)
   },
   postSubject: (data: {
-    subject: string
+    name: string
     category: string
     description: string
   }) => axiosClient.post(URLs.subjects.post, data),

--- a/src/services/subject-service.ts
+++ b/src/services/subject-service.ts
@@ -18,5 +18,10 @@ export const subjectService = {
   ): Promise<AxiosResponse<SubjectNameInterface[]>> => {
     const category = createUrlPath(URLs.categories.get, categoryId)
     return axiosClient.get(`${category}${URLs.subjects.getNames}`)
-  }
+  },
+  postSubject: (data: {
+    subject: string
+    category: string
+    description: string
+  }) => axiosClient.post(URLs.subjects.post, data)
 }

--- a/src/services/subject-service.ts
+++ b/src/services/subject-service.ts
@@ -2,7 +2,12 @@ import { axiosClient } from '~/plugins/axiosClient'
 import { AxiosResponse } from 'axios'
 
 import { URLs } from '~/constants/request'
-import { ItemsWithCount, SubjectInterface, SubjectNameInterface } from '~/types'
+import {
+  ItemsWithCount,
+  SubjectInterface,
+  SubjectNameInterface,
+  SubjectParams
+} from '~/types'
 import { createUrlPath } from '~/utils/helper-functions'
 
 export const subjectService = {
@@ -24,7 +29,7 @@ export const subjectService = {
     category: string
     description: string
   }) => axiosClient.post(URLs.subjects.post, data),
-  getAllSubjects: () => {
-    return axiosClient.get(`${URLs.subjects.get}`)
+  getAllSubjects: (params?: SubjectParams) => {
+    return axiosClient.get(`${URLs.subjects.get}`, { params })
   }
 }

--- a/src/types/common/interfaces/common.interfaces.ts
+++ b/src/types/common/interfaces/common.interfaces.ts
@@ -79,6 +79,11 @@ export interface SubjectInterface {
   updatedAt: string
 }
 
+export interface SubjectParams {
+  limit?: number
+  categoryId?: string
+}
+
 export interface SubjectNameInterface {
   _id: string
   name: string


### PR DESCRIPTION
🔧 What’s been implemented:
Added logic for submitting the “Create Subject” form to the server
![image](https://github.com/user-attachments/assets/c493bb26-1df9-464e-9dc4-ea0d7bd8f15d)


Implemented response handling:

✅ On success: subject is added, success snackbar is shown, and the modal is closed
![image](https://github.com/user-attachments/assets/a3f1be7e-fdde-4b71-b83f-5d2d9ea2b58e)


⚠️ If the subject already exists: appropriate error message is shown
![image](https://github.com/user-attachments/assets/1938ef2a-1513-4c92-843f-4967cf05e452)

Added a confirmation dialog when attempting to close the modal with unsaved changes
![image](https://github.com/user-attachments/assets/502b9e53-a417-40c4-b3f1-e19a18718e9e)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to create new subjects, including specifying a name, category, and description.
- **Improvements**
  - Subject creation and validation fields have been renamed for clarity.
  - Subject fetching now supports limiting the number of results and filtering by category.
  - Improved form handling and unsaved changes tracking in the subject creation modal.
- **Documentation**
  - Updated user-facing instructions for adding a new subject.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->