### PR TITLE
#310: Rewrite tests for SearchFilterInput using userEvent instead of fireEvent

### DIFF
--- a/src/tests/unit/components/search-filter-input/SearchFilterInput.spec.jsx
+++ b/src/tests/unit/components/search-filter-input/SearchFilterInput.spec.jsx
@@ -1,5 +1,6 @@
 import { vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import SearchFilterInput from '~/components/search-filter-input/SearchFilterInput'
 
 vi.mock('react-i18next', () => ({
@@ -22,32 +23,28 @@ describe('SearchFilterInput', () => {
     expect(input).toBeInTheDocument()
   })
 
-  it('should render typed text correctly', () => {
-    fireEvent.change(input, { target: { value: 'some text' } })
+  it('should render typed text correctly', async () => {
+    await userEvent.type(input, 'some text')
     expect(input).toHaveValue('some text')
   })
 
-  it('should delete typed text when delete button is clicked', () => {
-    fireEvent.change(input, { target: { value: 'text' } })
+  it('should delete typed text when delete button is clicked', async () => {
+    await userEvent.type(input, 'text')
     const clearButton = screen.getByTestId('clearIcon')
-    fireEvent.click(clearButton)
+    await userEvent.click(clearButton)
     expect(input).toHaveValue('')
   })
 
-  it('should call updateFilter function on search button click', () => {
+  it('should call updateFilter function on search button click', async () => {
     const searchButton = screen.getByText('common.search')
-
-    fireEvent.change(input, { target: { value: 'some query' } })
-    fireEvent.click(searchButton)
-
+    await userEvent.type(input, 'some query')
+    await userEvent.click(searchButton)
     expect(updateFilter).toHaveBeenCalledWith('some query')
     expect(updateFilter).toHaveBeenCalledTimes(1)
   })
 
-  it('should call updateFilter function when enter is pressed', () => {
-    fireEvent.change(input, { target: { value: 'enter text' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-
+  it('should call updateFilter function when enter is pressed', async () => {
+    await userEvent.type(input, 'enter text{enter}')
     expect(updateFilter).toHaveBeenCalledWith('enter text')
     expect(updateFilter).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
<img width="769" alt="Image" src="https://github.com/user-attachments/assets/41ba8872-725c-4588-a7f4-ab6fa68e6565" />

<img width="616" alt="Image" src="https://github.com/user-attachments/assets/ee317d07-bc39-4002-8225-f4f4e944d38f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated tests to use more realistic user interaction simulation, improving accuracy by replacing direct event triggers with asynchronous user events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->