### PR TITLE
#311: Adjust card widths to be consistent

### DIFF
--- a/src/components/offer-card/OfferCard.tsx
+++ b/src/components/offer-card/OfferCard.tsx
@@ -35,7 +35,7 @@ const OfferCard: FC<OfferCardProps & { isGridView: boolean }> = ({
   isGridView,
   ...props
 }) => {
-  const isLargeScreen = useMediaQuery('(min-width: 660px)')
+  const isLargeScreen = useMediaQuery('(min-width: 730px)')
   if (isGridView || !isLargeScreen) {
     return <OfferCardSquare {...props} />
   } else {

--- a/src/components/offer-card/offer-card-rectangle/OfferCardRectangle.styles.ts
+++ b/src/components/offer-card/offer-card-rectangle/OfferCardRectangle.styles.ts
@@ -3,7 +3,7 @@ export const styles = {
     p: 3,
     borderRadius: 3,
     boxShadow: 1,
-    maxWidth: 1100,
+    width: 834,
     m: 'auto',
     bgcolor: 'background.paper'
   },

--- a/src/containers/find-offer/offer-cards-list/OfferCardsList.tsx
+++ b/src/containers/find-offer/offer-cards-list/OfferCardsList.tsx
@@ -87,7 +87,7 @@ const OfferCardsList: FC<OfferCardsListProps> = ({
       {isGridView ? (
         <Grid container spacing={2}>
           {paginatedOffers.map((offer) => (
-            <Grid item key={offer._id} md={4} sm={6} xs={12}>
+            <Grid item key={offer._id} lg={4} md={6} xs={12}>
               <Box sx={styles.container}>
                 <OfferCard
                   isGridView={isGridView}


### PR DESCRIPTION
Before:
<img width="843" alt="Знімок екрана 2025-05-15 о 16 54 57" src="https://github.com/user-attachments/assets/1371af59-23ee-49e0-8d73-a08a860d448b" />

After:
<img width="916" alt="Знімок екрана 2025-05-15 о 16 53 57" src="https://github.com/user-attachments/assets/ed8fb0bb-c1dc-46b8-8591-e395e6063b5b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted card sizing to use a fixed width for a more consistent appearance.
  - Updated grid layout for offer cards to improve responsiveness across screen sizes.

- **New Features**
  - Increased the screen width threshold for switching between square and rectangle offer card layouts, providing a better experience on wider screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->